### PR TITLE
Cs 221 chore/community jira 이슈 생성 규칙 변경

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/chore-issue-form.yml
@@ -16,7 +16,7 @@ body:
     id : parentKey
     attributes:
       label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
-      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      description: '상위 작업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feat-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/feat-issue-form.yml
@@ -16,7 +16,7 @@ body:
     id : parentKey
     attributes:
       label: '상위 직업 (Epic, 보라색 번개) Ticket Number'
-      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number 기입해주세요, 노션에서도 확인 가능'
+      description: '상위 작업 (Epic, 보라색 아이콘) 의 Ticket Number 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feat-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/feat-issue-form.yml
@@ -15,7 +15,7 @@ body:
   - type : input
     id : parentKey
     attributes:
-      label: '상위 직업 (Epic, 보라색 번개) Ticket Number'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
       description: '상위 작업 (Epic, 보라색 아이콘) 의 Ticket Number 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:

--- a/.github/ISSUE_TEMPLATE/fix-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/fix-issue-form.yml
@@ -12,11 +12,11 @@ body:
         제목은 반드시 `Fix/ ~` 형식으로 작성해주세요.  
         예: `Fix/A 기능 중 B 에러`
 
-  - type : input
-    id : parentKey
+  - type: input
+    id: parentKey
     attributes:
-      label: '상위 작업 (Story, 초록색 책갈피) Ticket Number'
-      description: '상위 직업 (Story, 초록색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 작업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/performance-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/performance-issue-form.yml
@@ -12,11 +12,11 @@ body:
         제목은 반드시 `Performance/ ~` 형식으로 작성해주세요.  
         예: `Performance/A 기능 성능 개선`
 
-  - type : input
-    id : parentKey
+  - type: input
+    id: parentKey
     attributes:
-      label: '상위 작업 (Story, 초록색 책갈피) Ticket Number'
-      description: '상위 직업 (Story, 초록색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 작업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/refactor-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/refactor-issue-form.yml
@@ -12,11 +12,11 @@ body:
         제목은 반드시 `Refactor/ ~` 형식으로 작성해주세요.  
         예: `Refactor/A 기능 리팩토링`
 
-  - type : input
-    id : parentKey
+  - type: input
+    id: parentKey
     attributes:
-      label: '상위 작업 (Story, 초록색 책갈피) Ticket Number'
-      description: '상위 직업 (Story, 초록색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 작업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/workflows/create-jira-chore-issue.yml
+++ b/.github/workflows/create-jira-chore-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 스토리
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-feat-issue.yml
+++ b/.github/workflows/create-jira-feat-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 스토리
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-fix-issue.yml
+++ b/.github/workflows/create-jira-fix-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 하위 작업 # Task, Subtask 아님!
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-performance-issue.yml
+++ b/.github/workflows/create-jira-performance-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 하위 작업 # Task, Subtask 아님!
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-refactor-issue.yml
+++ b/.github/workflows/create-jira-refactor-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 하위 작업 # Task, Subtask 아님!
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
Task가 생성되도록 변경했습니다
---

## 🔗 관련 이슈
- closes #15 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
  - 이슈 템플릿의 한글 오타(“직업” → “작업”)를 “상위 작업”으로 일관되게 수정하고, 아이콘 및 설명 문구를 개선했습니다.
  - 입력 필드의 라벨과 설명에서 “Story(초록색 북마크)”를 “Epic(보라색 번개)”로 변경했습니다.
  - 입력 필드 정의의 불필요한 공백을 제거하여 포맷을 정비했습니다.

- **Chore**
  - Jira 이슈 생성 워크플로우에서 이슈 타입을 한글(“스토리”, “하위 작업”)에서 영어(“Task”)로 통일했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->