### PR TITLE
Feat: 글 조회 및 글 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/comment/dto/comment_delete/CommentDeleteRequest.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/dto/comment_delete/CommentDeleteRequest.java
@@ -5,11 +5,12 @@ import lombok.Builder;
 
 @Builder
 public record CommentDeleteRequest(
-    @NotNull(message = "commentId는 null일 수 없습니다!")
-    Long commentId,
 
-    @NotNull(message =  "commentGroupID는 null일 수 없습니다.")
-    Long commentGroupId
+        @NotNull(message = "commentId는 null일 수 없습니다!")
+        Long commentId,
+
+        @NotNull(message =  "commentGroupID는 null일 수 없습니다.")
+        Long commentGroupId
 ) {
     public static CommentDeleteRequest of(Long commentId, Long commentGroupId) {
         return CommentDeleteRequest.builder()

--- a/src/main/java/com/playus/communityservice/domain/comment/repository/write/CommentRepository.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/repository/write/CommentRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByCommentGroup(CommentGroup commentGroup);
+    List<Comment> findAllByCommentGroup_Post(Post post);
 }

--- a/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
@@ -16,6 +16,7 @@ import com.playus.communityservice.domain.post.specification.PostControllerSpeci
 import com.playus.communityservice.global.jwt.JwtUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -67,8 +68,12 @@ public class PostController implements PostControllerSpecification {
     }
 
     @GetMapping("/posts/{teamName}")
-    public ResponseEntity<List<PostListResponse>> getPostsByTeam(@PathVariable("teamName") TeamTag teamName) {
-        List<PostListResponse> response = postService.getPostsByTeam(teamName);
+    public ResponseEntity<List<PostListResponse>> getPostsByTeam(
+            @PathVariable("teamName") TeamTag teamName,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        List<PostListResponse> response = postService.getPostsByTeam(teamName, page, size);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
@@ -1,5 +1,7 @@
 package com.playus.communityservice.domain.post.controller;
 
+import com.playus.communityservice.domain.post.dto.PostGetResponse;
+import com.playus.communityservice.domain.post.dto.PostListResponse;
 import com.playus.communityservice.domain.post.dto.post_create.PostCreateRequest;
 import com.playus.communityservice.domain.post.dto.post_create.PostCreateResponse;
 import com.playus.communityservice.domain.post.dto.post_delete.PostDeleteRequest;
@@ -19,6 +21,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/post")
@@ -27,7 +30,7 @@ public class PostController implements PostControllerSpecification {
 
     private final PostService postService;
 
-    @PostMapping("/{tag}")
+    @PostMapping
     public ResponseEntity<PostCreateResponse> createPost(@PathVariable TeamTag tag,
                                                      @Valid @RequestBody PostCreateRequest request,
                                                      @AuthenticationPrincipal JwtUser user) {
@@ -36,7 +39,7 @@ public class PostController implements PostControllerSpecification {
         return ResponseEntity.created(location).body(response);
     }
 
-    @PatchMapping("/{tag}")
+    @PatchMapping
     public ResponseEntity<PostUpdateResponse> updatePost(@PathVariable TeamTag tag,
                                                      @Valid @RequestBody PostUpdateRequest request,
                                                      @AuthenticationPrincipal JwtUser user) {
@@ -55,4 +58,18 @@ public class PostController implements PostControllerSpecification {
     public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(@Valid @RequestBody PresignedUrlForSaveImageRequest request) {
         return postService.generatePresignedUrlForSaveImage(request);
     }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostGetResponse> getPost(@PathVariable Long postId,
+                                                   @AuthenticationPrincipal JwtUser user) {
+        PostGetResponse response = postService.getPost(postId, user);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/posts/{teamName}")
+    public ResponseEntity<List<PostListResponse>> getPostsByTeam(@PathVariable("teamName") TeamTag teamName) {
+        List<PostListResponse> response = postService.getPostsByTeam(teamName);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/playus/communityservice/domain/post/dto/PostGetResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/post/dto/PostGetResponse.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 @Builder
 public record PostGetResponse(
+        Long postId,
         String title,
         LocalDate date,
         String writerNickname,
@@ -17,6 +18,7 @@ public record PostGetResponse(
         List<CommentDto> comments
 ) {
     public record CommentDto(
+            Long commentId,
             String writerNickname,
             String writerProfileImage,
             boolean isExpert,
@@ -25,6 +27,7 @@ public record PostGetResponse(
     ) {}
 
     public record ReCommentDto(
+            Long reCommentId,
             String writerNickname,
             String writerProfileImage,
             boolean isExpert,

--- a/src/main/java/com/playus/communityservice/domain/post/dto/PostGetResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/post/dto/PostGetResponse.java
@@ -1,0 +1,33 @@
+package com.playus.communityservice.domain.post.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record PostGetResponse(
+        String title,
+        LocalDate date,
+        String writerNickname,
+        String writerProfileImage,
+        boolean isExpert,
+        String image,
+        String content,
+        List<CommentDto> comments
+) {
+    public record CommentDto(
+            String writerNickname,
+            String writerProfileImage,
+            boolean isExpert,
+            String content,
+            List<ReCommentDto> reComments
+    ) {}
+
+    public record ReCommentDto(
+            String writerNickname,
+            String writerProfileImage,
+            boolean isExpert,
+            String content
+    ) {}
+}

--- a/src/main/java/com/playus/communityservice/domain/post/dto/PostListResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/post/dto/PostListResponse.java
@@ -3,6 +3,7 @@ package com.playus.communityservice.domain.post.dto;
 import java.time.LocalDate;
 
 public record PostListResponse(
+        Long postId,
         String title,
         LocalDate date,
         String writerNickname,

--- a/src/main/java/com/playus/communityservice/domain/post/dto/PostListResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/post/dto/PostListResponse.java
@@ -1,0 +1,10 @@
+package com.playus.communityservice.domain.post.dto;
+
+import java.time.LocalDate;
+
+public record PostListResponse(
+        String title,
+        LocalDate date,
+        String writerNickname,
+        String image
+) {}

--- a/src/main/java/com/playus/communityservice/domain/post/repository/write/PostRepository.java
+++ b/src/main/java/com/playus/communityservice/domain/post/repository/write/PostRepository.java
@@ -1,7 +1,11 @@
 package com.playus.communityservice.domain.post.repository.write;
 
 import com.playus.communityservice.domain.post.entity.Post;
+import com.playus.communityservice.domain.post.enums.TeamTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findAllByTag(TeamTag tag);
 }

--- a/src/main/java/com/playus/communityservice/domain/post/repository/write/PostRepository.java
+++ b/src/main/java/com/playus/communityservice/domain/post/repository/write/PostRepository.java
@@ -2,10 +2,13 @@ package com.playus.communityservice.domain.post.repository.write;
 
 import com.playus.communityservice.domain.post.entity.Post;
 import com.playus.communityservice.domain.post.enums.TeamTag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByTag(TeamTag tag);
+    Page<Post> findAllByTag(TeamTag tag, Pageable pageable);
 }

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
@@ -22,6 +22,9 @@ import com.playus.communityservice.global.exception.EntityNotFoundException;
 import com.playus.communityservice.global.exception.ForbiddenAccessException;
 import com.playus.communityservice.global.s3.S3Service;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -98,12 +101,17 @@ public class PostService {
 
         List<Comment> allComments = commentRepository.findAllByCommentGroup_Post(post);
 
+        if (!post.isActivated()) {
+            throw new EntityNotFoundException("게시글");
+        }
+
         List<PostGetResponse.CommentDto> comments = allComments.stream()
                 .filter(c -> c.getCommentOrder() == 1L)
                 .map(comment -> {
                     List<PostGetResponse.ReCommentDto> reComments = allComments.stream()
                             .filter(reply -> reply.getCommentGroup().equals(comment.getCommentGroup()) && reply.getCommentOrder() > 1L)
                             .map(reply -> new PostGetResponse.ReCommentDto(
+                                    comment.getId(),
                                     getNickname(reply.getUserId()),
                                     getProfileImage(reply.getUserId()),
                                     isExpert(reply.getUserId()),
@@ -112,6 +120,7 @@ public class PostService {
                             .toList();
 
                     return new PostGetResponse.CommentDto(
+                            comment.getId(),
                             getNickname(comment.getUserId()),
                             getProfileImage(comment.getUserId()),
                             isExpert(comment.getUserId()),
@@ -122,6 +131,7 @@ public class PostService {
                 .toList();
 
         return new PostGetResponse(
+                post.getId(),
                 post.getTitle(),
                 post.getJwpDate(),
                 getNickname(post.getWriterId()),
@@ -133,11 +143,14 @@ public class PostService {
         );
     }
 
-    public List<PostListResponse> getPostsByTeam(TeamTag tag) {
-        List<Post> posts = postRepository.findAllByTag(tag);
+    public List<PostListResponse> getPostsByTeam(TeamTag tag, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Post> postPage = postRepository.findAllByTag(tag, pageable);
+        List<Post> posts = postPage.getContent();
 
         return posts.stream()
                 .map(post -> new PostListResponse(
+                        post.getId(),
                         post.getTitle(),
                         post.getJwpDate(),
                         getNickname(post.getWriterId()),

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
@@ -99,11 +99,11 @@ public class PostService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("게시글"));
 
-        List<Comment> allComments = commentRepository.findAllByCommentGroup_Post(post);
-
         if (!post.isActivated()) {
             throw new EntityNotFoundException("게시글");
         }
+
+        List<Comment> allComments = commentRepository.findAllByCommentGroup_Post(post);
 
         List<PostGetResponse.CommentDto> comments = allComments.stream()
                 .filter(c -> c.getCommentOrder() == 1L)
@@ -111,7 +111,7 @@ public class PostService {
                     List<PostGetResponse.ReCommentDto> reComments = allComments.stream()
                             .filter(reply -> reply.getCommentGroup().equals(comment.getCommentGroup()) && reply.getCommentOrder() > 1L)
                             .map(reply -> new PostGetResponse.ReCommentDto(
-                                    comment.getId(),
+                                    reply.getId(),
                                     getNickname(reply.getUserId()),
                                     getProfileImage(reply.getUserId()),
                                     isExpert(reply.getUserId()),

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
@@ -4,6 +4,8 @@ import com.playus.communityservice.domain.comment.entity.Comment;
 import com.playus.communityservice.domain.comment.entity.CommentGroup;
 import com.playus.communityservice.domain.comment.repository.write.CommentGroupRepository;
 import com.playus.communityservice.domain.comment.repository.write.CommentRepository;
+import com.playus.communityservice.domain.post.dto.PostGetResponse;
+import com.playus.communityservice.domain.post.dto.PostListResponse;
 import com.playus.communityservice.domain.post.dto.post_create.PostCreateRequest;
 import com.playus.communityservice.domain.post.dto.post_create.PostCreateResponse;
 import com.playus.communityservice.domain.post.dto.post_delete.PostDeleteRequest;
@@ -90,4 +92,70 @@ public class PostService {
         return new PresignedUrlForSaveImageResponse(s3Service.generatePresignedUrl(request.imageFileName()));
     }
 
+    public PostGetResponse getPost(Long postId, JwtUser user) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("게시글"));
+
+        List<Comment> allComments = commentRepository.findAllByCommentGroup_Post(post);
+
+        List<PostGetResponse.CommentDto> comments = allComments.stream()
+                .filter(c -> c.getCommentOrder() == 1L)
+                .map(comment -> {
+                    List<PostGetResponse.ReCommentDto> reComments = allComments.stream()
+                            .filter(reply -> reply.getCommentGroup().equals(comment.getCommentGroup()) && reply.getCommentOrder() > 1L)
+                            .map(reply -> new PostGetResponse.ReCommentDto(
+                                    getNickname(reply.getUserId()),
+                                    getProfileImage(reply.getUserId()),
+                                    isExpert(reply.getUserId()),
+                                    reply.getContent()
+                            ))
+                            .toList();
+
+                    return new PostGetResponse.CommentDto(
+                            getNickname(comment.getUserId()),
+                            getProfileImage(comment.getUserId()),
+                            isExpert(comment.getUserId()),
+                            comment.getContent(),
+                            reComments
+                    );
+                })
+                .toList();
+
+        return new PostGetResponse(
+                post.getTitle(),
+                post.getJwpDate(),
+                getNickname(post.getWriterId()),
+                getProfileImage(post.getWriterId()),
+                isExpert(post.getWriterId()),
+                post.getImageUrl(),
+                post.getDescription(),
+                comments
+        );
+    }
+
+    public List<PostListResponse> getPostsByTeam(TeamTag tag) {
+        List<Post> posts = postRepository.findAllByTag(tag);
+
+        return posts.stream()
+                .map(post -> new PostListResponse(
+                        post.getTitle(),
+                        post.getJwpDate(),
+                        getNickname(post.getWriterId()),
+                        post.getImageUrl()
+                ))
+                .toList();
+    }
+
+    private String getNickname(Long userId) {
+        return "User#" + userId; // TODO: 유저 서비스 연동
+    }
+
+    private String getProfileImage(Long userId) {
+        return "https://example.com/profile/" + userId + ".png"; // TODO: 유저 서비스 연동
+    }
+
+    private boolean isExpert(Long userId) {
+        return false; // TODO: 유저 서비스 연동
+    }
 }
+

--- a/src/main/java/com/playus/communityservice/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/playus/communityservice/global/exception/ExceptionAdvice.java
@@ -5,6 +5,7 @@ import com.playus.communityservice.domain.post.controller.PostController;
 import com.playus.communityservice.global.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -53,6 +54,16 @@ public class ExceptionAdvice {
         String errorMessage = e.getMessage();
         log.error("Forbidden Access Error: {}", errorMessage);
         return ErrorResponse.forbiddenError(errorMessage);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        String paramName = ex.getName(); // 예: "postId"
+        String invalidValue = String.valueOf(ex.getValue()); // 예: "asdf"
+        String message = String.format("'%s' 파라미터에 잘못된 값 '%s'이(가) 들어왔습니다.", paramName, invalidValue);
+        log.warn("Type Mismatch Error: {}", message);
+        return ErrorResponse.badRequestError(message);
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -47,5 +47,8 @@ sentry:
 logging:
   config: classpath:logback-spring.xml
 
+server:
+  port: 8082
+
 slack:
   webhook-url: ${SLACK_WEBHOOK_URL}


### PR DESCRIPTION
- 커뮤니티 글 조회 시 해당 ID의 모든 댓글과 답글도 조회 가능
- 팀 네임에 따른 목록 조회 기능

## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
![image](https://github.com/user-attachments/assets/abd7a47d-3e0b-4130-871f-f98346348241)
PostController에 새로운 기능 코드를 추가했습니다.

 
![image](https://github.com/user-attachments/assets/a27a5530-e9e2-4696-ac21-bc560a9ff1de)
PostService에 새로운 기능 코드를 추가했습니다.
위의 사진은 글 목록 조회 기능입니다.

- dto에 PostGetResponse와 PostListResponse도 추가하였습니다.

---

## 🔗 관련 이슈
- closes #28 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 게시글 단건 조회 및 팀별 게시글 목록 조회 기능이 추가되었습니다.
  - 게시글 조회 시 댓글 및 대댓글 정보가 함께 제공됩니다.
  - 댓글 그룹 내 게시글 관련 댓글 전체 조회 기능이 추가되었습니다.

- **버그 수정**
  - 게시글 생성 및 수정 시 팀 태그 입력 방식이 변경되었습니다.

- **환경설정**
  - 서버 포트가 8082로 설정되었습니다.

- **기타**
  - 잘못된 요청 파라미터 타입에 대한 상세 오류 응답이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->