### PR TITLE
Feat: 직관일지 작성 API 구현

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
@@ -20,7 +20,7 @@ public class LiveMatchDiaryController {
 
     private final PostService postService;
 
-    @PostMapping
+    @PostMapping("/{tag}")
     public ResponseEntity<PostCreateResponse> createPost(@PathVariable TeamTag tag,
                                                          @Valid @RequestBody PostCreateRequest request,
                                                          @AuthenticationPrincipal JwtUser user) {

--- a/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
@@ -25,7 +25,6 @@ public class LiveMatchDiaryController {
                                                          @Valid @RequestBody PostCreateRequest request,
                                                          @AuthenticationPrincipal JwtUser user) {
         PostCreateResponse response = postService.createPost(request, user, tag);
-        URI location = URI.create("/live-match-diary/" + response.postId());
-        return ResponseEntity.created(location).body(response);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
@@ -1,0 +1,31 @@
+package com.playus.communityservice.domain.post.controller;
+
+import com.playus.communityservice.domain.post.dto.post_create.PostCreateRequest;
+import com.playus.communityservice.domain.post.dto.post_create.PostCreateResponse;
+import com.playus.communityservice.domain.post.enums.TeamTag;
+import com.playus.communityservice.domain.post.service.PostService;
+import com.playus.communityservice.global.jwt.JwtUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/live-match-diary")
+@RequiredArgsConstructor
+public class LiveMatchDiaryController {
+
+    private final PostService postService;
+
+    @PostMapping
+    public ResponseEntity<PostCreateResponse> createPost(@PathVariable TeamTag tag,
+                                                         @Valid @RequestBody PostCreateRequest request,
+                                                         @AuthenticationPrincipal JwtUser user) {
+        PostCreateResponse response = postService.createPost(request, user, tag);
+        URI location = URI.create("/live-match-diary/" + response.postId());
+        return ResponseEntity.created(location).body(response);
+    }
+}

--- a/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
@@ -38,7 +38,7 @@ public class PostController implements PostControllerSpecification {
                                                      @AuthenticationPrincipal JwtUser user) {
         PostCreateResponse response = postService.createPost(request, user, tag);
         URI location = URI.create("/post/" + response.postId());
-        return ResponseEntity.created(location).body(response);
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping("/{tag}")

--- a/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
@@ -71,6 +71,7 @@ public class PostController implements PostControllerSpecification {
     @GetMapping("/posts/{teamName}")
     public ResponseEntity<List<PostListResponse>> getPostsByTeam(
             @PathVariable("teamName") TeamTag teamName,
+            @AuthenticationPrincipal JwtUser user,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {

--- a/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
@@ -17,7 +17,6 @@ import com.playus.communityservice.domain.post.specification.PostControllerSpeci
 import com.playus.communityservice.global.jwt.JwtUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -33,7 +32,7 @@ public class PostController implements PostControllerSpecification {
     private final PostService postService;
     private final PostReadOnlyService postReadOnlyService;
 
-    @PostMapping
+    @PostMapping("/{tag}")
     public ResponseEntity<PostCreateResponse> createPost(@PathVariable TeamTag tag,
                                                      @Valid @RequestBody PostCreateRequest request,
                                                      @AuthenticationPrincipal JwtUser user) {
@@ -42,7 +41,7 @@ public class PostController implements PostControllerSpecification {
         return ResponseEntity.created(location).body(response);
     }
 
-    @PatchMapping
+    @PatchMapping("/{tag}")
     public ResponseEntity<PostUpdateResponse> updatePost(@PathVariable TeamTag tag,
                                                      @Valid @RequestBody PostUpdateRequest request,
                                                      @AuthenticationPrincipal JwtUser user) {

--- a/src/main/java/com/playus/communityservice/domain/post/document/PostDocument.java
+++ b/src/main/java/com/playus/communityservice/domain/post/document/PostDocument.java
@@ -38,7 +38,7 @@ public class PostDocument {
     private boolean isSecret;
 
     @Field(name = "jwp_date")
-    private LocalDate jwpDate;
+    private LocalDate twpDate;
 
     @Field(name = "image_url")
     private String imageUrl;
@@ -48,7 +48,7 @@ public class PostDocument {
 
 
     @Builder
-    private PostDocument(Long id, String title, String description, TeamTag tag, Long writerId, boolean activated, boolean isSecret, String imageUrl, LocalDate jwpDate, int view) {
+    private PostDocument(Long id, String title, String description, TeamTag tag, Long writerId, boolean activated, boolean isSecret, String imageUrl, LocalDate twpDate, int view) {
         this.id = id;
         this.title = title;
         this.description = description;
@@ -56,12 +56,12 @@ public class PostDocument {
         this.writerId = writerId;
         this.activated = activated;
         this.isSecret = isSecret;
-        this.jwpDate = jwpDate;
+        this.twpDate = twpDate;
         this.imageUrl = imageUrl;
         this.view = view;
     }
 
-    public static PostDocument createForOnlyTest(Long id, Long writerId, String title, String description, TeamTag tag, String imageUrl, LocalDate jwpDate, int view) {
+    public static PostDocument createForOnlyTest(Long id, Long writerId, String title, String description, TeamTag tag, String imageUrl, LocalDate twpDate, int view) {
         return PostDocument.builder()
                 .id(id)
                 .writerId(writerId)
@@ -70,7 +70,7 @@ public class PostDocument {
                 .tag(tag)
                 .activated(true)
                 .isSecret(false)
-                .jwpDate(jwpDate)
+                .twpDate(twpDate)
                 .imageUrl(imageUrl)
                 .view(view)
                 .build();

--- a/src/main/java/com/playus/communityservice/domain/post/dto/PostGetResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/post/dto/PostGetResponse.java
@@ -12,7 +12,7 @@ public record PostGetResponse(
         LocalDate date,
         String writerNickname,
         String writerProfileImage,
-        boolean isExpert,
+        boolean activated,
         String image,
         String content,
         List<CommentDto> comments
@@ -21,7 +21,7 @@ public record PostGetResponse(
             Long commentId,
             String writerNickname,
             String writerProfileImage,
-            boolean isExpert,
+            boolean activated,
             String content,
             List<ReCommentDto> reComments
     ) {}
@@ -30,7 +30,7 @@ public record PostGetResponse(
             Long reCommentId,
             String writerNickname,
             String writerProfileImage,
-            boolean isExpert,
+            boolean activated,
             String content
     ) {}
 }

--- a/src/main/java/com/playus/communityservice/domain/post/dto/post_create/PostCreateRequest.java
+++ b/src/main/java/com/playus/communityservice/domain/post/dto/post_create/PostCreateRequest.java
@@ -19,16 +19,25 @@ public record PostCreateRequest(
         String content,
 
         @JsonFormat(pattern = "yyyy-MM-dd")
-        LocalDate jwpDate
+        LocalDate jwpDate,
+
+        boolean isSecret
 
 ) {
 
-    public static PostCreateRequest of(String title, String image , String content, LocalDate jwpDate) {
+    public static PostCreateRequest of(String title, String image , String content, LocalDate jwpDate, boolean isSecret) {
         return PostCreateRequest.builder()
                 .title(title)
                 .image(image)
                 .content(content)
                 .jwpDate(jwpDate)
+                .isSecret(isSecret)
                 .build();
+    }
+
+    public void validate() {
+        if (isSecret && jwpDate == null) {
+            throw new IllegalArgumentException("직관일지의 경우 jwpDate는 필수입니다.");
+        }
     }
 }

--- a/src/main/java/com/playus/communityservice/domain/post/dto/post_create/PostCreateRequest.java
+++ b/src/main/java/com/playus/communityservice/domain/post/dto/post_create/PostCreateRequest.java
@@ -19,25 +19,25 @@ public record PostCreateRequest(
         String content,
 
         @JsonFormat(pattern = "yyyy-MM-dd")
-        LocalDate jwpDate,
+        LocalDate twpDate,
 
         boolean isSecret
 
 ) {
 
-    public static PostCreateRequest of(String title, String image , String content, LocalDate jwpDate, boolean isSecret) {
+    public static PostCreateRequest of(String title, String image , String content, LocalDate twpDate, boolean isSecret) {
         return PostCreateRequest.builder()
                 .title(title)
                 .image(image)
                 .content(content)
-                .jwpDate(jwpDate)
+                .twpDate(twpDate)
                 .isSecret(isSecret)
                 .build();
     }
 
     public void validate() {
-        if (isSecret && jwpDate == null) {
-            throw new IllegalArgumentException("직관일지의 경우 jwpDate는 필수입니다.");
+        if (isSecret && twpDate == null) {
+            throw new IllegalArgumentException("직관일지의 경우 twpDate는 필수입니다.");
         }
     }
 }

--- a/src/main/java/com/playus/communityservice/domain/post/dto/post_update/PostUpdateRequest.java
+++ b/src/main/java/com/playus/communityservice/domain/post/dto/post_update/PostUpdateRequest.java
@@ -25,16 +25,16 @@ public record PostUpdateRequest(
         String content,
 
         @JsonFormat(pattern = "yyyy-MM-dd")
-        LocalDate jwpDate
+        LocalDate twpDate
 ) {
 
-    public static PostUpdateRequest of(Long postId, String title, String image, String content, LocalDate jwpDate) {
+    public static PostUpdateRequest of(Long postId, String title, String image, String content, LocalDate twpDate) {
         return PostUpdateRequest.builder()
                 .postId(postId)
                 .title(title)
                 .image(image)
                 .content(content)
-                .jwpDate(jwpDate)
+                .twpDate(twpDate)
                 .build();
     }
 }

--- a/src/main/java/com/playus/communityservice/domain/post/entity/Post.java
+++ b/src/main/java/com/playus/communityservice/domain/post/entity/Post.java
@@ -27,8 +27,8 @@ public class Post extends BaseTimeEntity {
     @Column(nullable = false)
     private TeamTag tag;
 
-    @Column(name = "jwp_date")
-    private LocalDate jwpDate;
+    @Column(name = "twp_date")
+    private LocalDate twpDate;
 
     @Column(columnDefinition = "TEXT", nullable = false)
     private String description;
@@ -47,19 +47,19 @@ public class Post extends BaseTimeEntity {
 
 
     @Builder
-    private Post(String title, String description, TeamTag tag, Long writerId, boolean activated, boolean isSecret, LocalDate jwpDate, String imageUrl, int view) {
+    private Post(String title, String description, TeamTag tag, Long writerId, boolean activated, boolean isSecret, LocalDate twpDate, String imageUrl, int view) {
         this.title = title;
         this.description = description;
         this.tag = tag;
         this.writerId = writerId;
         this.activated = activated;
         this.isSecret = isSecret;
-        this.jwpDate = jwpDate;
+        this.twpDate = twpDate;
         this.imageUrl = imageUrl;
         this.view = view;
     }
 
-    public static Post create(final Long writerId, final String title, final String description, final TeamTag tag, final LocalDate jwpDate, final String imageUrl, boolean isSecret) {
+    public static Post create(final Long writerId, final String title, final String description, final TeamTag tag, final LocalDate twpDate, final String imageUrl, boolean isSecret) {
         return Post.builder()
                 .writerId(writerId)
                 .title(title)
@@ -67,17 +67,17 @@ public class Post extends BaseTimeEntity {
                 .tag(tag)
                 .activated(true)
                 .isSecret(isSecret)
-                .jwpDate(jwpDate)
+                .twpDate(twpDate)
                 .imageUrl(imageUrl)
                 .build();
     }
 
-    public void updateAll(final String title, final String description, final TeamTag tag, final boolean isSecret, final LocalDate jwpDate, final String imageUrl) {
+    public void updateAll(final String title, final String description, final TeamTag tag, final boolean isSecret, final LocalDate twpDate, final String imageUrl) {
         this.title = title;
         this.description = description;
         this.tag = tag;
         this.isSecret = isSecret;
-        this.jwpDate = jwpDate;
+        this.twpDate = twpDate;
         this.imageUrl = imageUrl;
     }
 

--- a/src/main/java/com/playus/communityservice/domain/post/entity/Post.java
+++ b/src/main/java/com/playus/communityservice/domain/post/entity/Post.java
@@ -59,14 +59,14 @@ public class Post extends BaseTimeEntity {
         this.view = view;
     }
 
-    public static Post create(final Long writerId, final String title, final String description, final TeamTag tag, final LocalDate jwpDate, final String imageUrl) {
+    public static Post create(final Long writerId, final String title, final String description, final TeamTag tag, final LocalDate jwpDate, final String imageUrl, boolean isSecret) {
         return Post.builder()
                 .writerId(writerId)
                 .title(title)
                 .description(description)
                 .tag(tag)
                 .activated(true)
-                .isSecret(false)
+                .isSecret(isSecret)
                 .jwpDate(jwpDate)
                 .imageUrl(imageUrl)
                 .build();

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -66,7 +66,7 @@ public class PostReadOnlyService {
         return new PostGetResponse(
                 post.getId(),
                 post.getTitle(),
-                post.getJwpDate(),
+                post.getTwpDate(),
                 getNickname(post.getWriterId()),
                 getProfileImage(post.getWriterId()),
                 isExpert(post.getWriterId()),
@@ -86,7 +86,7 @@ public class PostReadOnlyService {
                 .map(post -> new PostListResponse(
                         post.getId(),
                         post.getTitle(),
-                        post.getJwpDate(),
+                        post.getTwpDate(),
                         getNickname(post.getWriterId()),
                         post.getImageUrl()
                 ))

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
@@ -50,7 +50,7 @@ public class PostService {
                 request.title(),
                 request.content(),
                 tag,
-                request.jwpDate(),
+                request.twpDate(),
                 request.image(),
                 false
         );
@@ -59,8 +59,8 @@ public class PostService {
     }
 
     private PostCreateResponse createDiary(PostCreateRequest request, JwtUser user, TeamTag tag) {
-        if (request.jwpDate() == null) {
-            throw new IllegalArgumentException("직관일지는 jwpDate가 필수입니다.");
+        if (request.twpDate() == null) {
+            throw new IllegalArgumentException("직관일지는 twpDate가 필수입니다.");
         }
 
         Post diary = Post.create(
@@ -68,7 +68,7 @@ public class PostService {
                 request.title(),
                 request.content(),
                 tag,
-                request.jwpDate(),
+                request.twpDate(),
                 request.image(),
                 true
         );
@@ -92,7 +92,7 @@ public class PostService {
             s3Service.deleteImage(fileName);
         }
 
-        post.updateAll(request.title(), request.content(), tag, false, request.jwpDate(), request.image());
+        post.updateAll(request.title(), request.content(), tag, false, request.twpDate(), request.image());
         return PostUpdateResponse.of(true, "게시물이 수정되었습니다.");
     }
 

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
@@ -37,12 +37,43 @@ public class PostService {
     private final CommentRepository commentRepository;
 
     public PostCreateResponse createPost(PostCreateRequest request, JwtUser user, TeamTag tag) {
-        Post post = Post.create(user.getId(), request.title(), request.content(), tag, request.jwpDate(), request.image());
-        postRepository.save(post);
+        if (request.isSecret()) {
+            return createDiary(request, user, tag);
+        } else {
+            return createGeneralPost(request, user, tag);
+        }
+    }
 
+    private PostCreateResponse createGeneralPost(PostCreateRequest request, JwtUser user, TeamTag tag) {
+        Post post = Post.create(
+                user.getId(),
+                request.title(),
+                request.content(),
+                tag,
+                request.jwpDate(),
+                request.image()
+        );
+        postRepository.save(post);
         return PostCreateResponse.of(post.getId(), "게시물 생성이 완료되었습니다.");
     }
 
+    private PostCreateResponse createDiary(PostCreateRequest request, JwtUser user, TeamTag tag) {
+        if (request.jwpDate() == null) {
+            throw new IllegalArgumentException("직관일지는 jwpDate가 필수입니다.");
+        }
+
+        Post diary = Post.create(
+                user.getId(),
+                request.title(),
+                request.content(),
+                tag,
+                request.jwpDate(),
+                request.image()
+        );
+        postRepository.save(diary);
+        return PostCreateResponse.of(diary.getId(), "직관일지 생성이 완료되었습니다.");
+    }
+    
 
     public PostUpdateResponse updatePost(PostUpdateRequest request, JwtUser user, TeamTag tag) {
         Post post = postRepository.findById(request.postId())

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
@@ -51,7 +51,8 @@ public class PostService {
                 request.content(),
                 tag,
                 request.jwpDate(),
-                request.image()
+                request.image(),
+                false
         );
         postRepository.save(post);
         return PostCreateResponse.of(post.getId(), "게시물 생성이 완료되었습니다.");
@@ -68,12 +69,13 @@ public class PostService {
                 request.content(),
                 tag,
                 request.jwpDate(),
-                request.image()
+                request.image(),
+                true
         );
         postRepository.save(diary);
         return PostCreateResponse.of(diary.getId(), "직관일지 생성이 완료되었습니다.");
     }
-    
+
 
     public PostUpdateResponse updatePost(PostUpdateRequest request, JwtUser user, TeamTag tag) {
         Post post = postRepository.findById(request.postId())

--- a/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
@@ -413,18 +413,18 @@ public interface PostControllerSpecification {
                                             	"date":"2025-03-20T00:00:00",
                                             	"writerNickname":"안타날릴",
                                             	"writerProfileImage":["profile.png"],
-                                            	"activated":"true",
+                                            	"activated":true,
                                             	"image":["image.png"],
                                             	"content":"오늘은 LG가 이겨서 너무 행복합니다.",
                                             	"comments":[
                                             		"writerNickname":"난리나리라",
                                             		"writerProfileImage":["profiles.png"],
-                                            		"activated":"true",
+                                            		"activated":true,
                                             		"content":"홈런터질때 정말 짜릿했어요",
                                             		"reComments":[
                                             			"writerNickname":"테스형",
                                             			"writerProfileImage":["profile_11.png"],
-                                            			"activated":"true",
+                                            			"activated":true,
                                             			"content":"인정입니다."
                                             		]
                                             	]

--- a/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
@@ -57,7 +57,7 @@ public interface PostControllerSpecification {
                                       "title": "오늘 경기 재밌었어요!",
                                       "image": ["post.jpg"],
                                       "content": "LG가 이길 줄 알았죠!",
-                                      "jwpDate" : "2025-05-05"
+                                      "twpDate" : "2025-05-05"
                                     }
                                     """
                             )
@@ -200,7 +200,7 @@ public interface PostControllerSpecification {
                                       "image": ["post.jpg"],
                                       "content": "긴장하면서 시청했네요."
                                       "postId": 1,
-                                      "jwpDate" : "2025-05-01"
+                                      "twpDate" : "2025-05-01"
                                     }
                                     """
                             )

--- a/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
@@ -1,11 +1,15 @@
 package com.playus.communityservice.domain.post.specification;
 
+import com.playus.communityservice.domain.post.dto.PostGetResponse;
+import com.playus.communityservice.domain.post.dto.PostListResponse;
 import com.playus.communityservice.domain.post.dto.post_create.PostCreateRequest;
 import com.playus.communityservice.domain.post.dto.post_create.PostCreateResponse;
 import com.playus.communityservice.domain.post.dto.post_delete.PostDeleteRequest;
 import com.playus.communityservice.domain.post.dto.post_delete.PostDeleteResponse;
 import com.playus.communityservice.domain.post.dto.post_update.PostUpdateRequest;
 import com.playus.communityservice.domain.post.dto.post_update.PostUpdateResponse;
+import com.playus.communityservice.domain.post.dto.presigned.PresignedUrlForSaveImageRequest;
+import com.playus.communityservice.domain.post.dto.presigned.PresignedUrlForSaveImageResponse;
 import com.playus.communityservice.domain.post.enums.TeamTag;
 import com.playus.communityservice.global.jwt.JwtUser;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,7 +22,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -101,7 +111,9 @@ public interface PostControllerSpecification {
                     )
             ),
     })
-    ResponseEntity<PostCreateResponse> createPost(TeamTag tag, PostCreateRequest request, JwtUser user);
+    ResponseEntity<PostCreateResponse> createPost(@PathVariable("tag") TeamTag tag,
+                                                  @Valid @Parameter(description = "게시글 생성 요청", required = true)
+                                                  PostCreateRequest request, JwtUser user);
 
     @Tag(name = "Post", description = "커뮤니티 글 삭제 API")
     @Operation(
@@ -169,7 +181,8 @@ public interface PostControllerSpecification {
                     )
             ),
     })
-    ResponseEntity<PostDeleteResponse> deletePost(PostDeleteRequest request, JwtUser user);
+    ResponseEntity<PostDeleteResponse> deletePost(@Valid @Parameter(description = "게시글 삭제 요청", required = true)
+                                                  PostDeleteRequest request, JwtUser user);
 
     @Tag(name = "Post", description = "커뮤니티 글 수정 API")
     @Operation(
@@ -271,6 +284,331 @@ public interface PostControllerSpecification {
                     )
             ),
     })
-    ResponseEntity<PostUpdateResponse> updatePost(TeamTag tag, PostUpdateRequest request, JwtUser user);
+    ResponseEntity<PostUpdateResponse> updatePost(@PathVariable("tag") TeamTag tag,
+                                                  @Valid @Parameter(description = "게시글 생성 요청", required = true)
+                                                  PostUpdateRequest request, JwtUser user);
+
+    @Tag(name = "Post", description = "Presigned URL 발급 API")
+    @Operation(
+            summary = "Presigned URL 발급",
+            description = "프론트에서 이미지를 직접 저장하기 위한 Presigned URL을 생성 및 반환합니다. (버킷에 저장할 때는 PUT으로)",
+            security = @SecurityRequirement(name = "Access"),
+            parameters = @Parameter(
+                    name = "Access",
+                    description = "JWT Access Token (쿠키)",
+                    in = ParameterIn.COOKIE,
+                    required = true,
+                    example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            ),
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "Presigned URL 발급 요청 예시",
+                                    value = """
+                                            {
+                                              "imageFileName": "party_thumbnail.jpg"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "발급 성공",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "Presigned URL 발급 응답 예시",
+                                    value = """
+                                            {
+                                              "presignedUrl": "http://presigned-url.com"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "이미지 파일명이 비어있을 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 400,
+                                              "status": "BAD_REQUEST",
+                                              "message": "이미지 파일명은 필수입니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "인증 실패",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 401,
+                                              "status": "UNAUTHORIZED",
+                                              "message": "유효하지 않은 토큰입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 500,
+                                              "status": "INTERNAL_SERVER_ERROR",
+                                              "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(@Valid @Parameter(description = "Presigned URL 발급 요청", required = true)
+                                                                      PresignedUrlForSaveImageRequest request);
+
+    @Tag(name = "Get", description = "커뮤니티 글 조회")
+    @Operation(
+            summary = "커뮤니티 글 조회 API",
+            description = "특정 게시물에 대한 자세한 정보를 조회합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "Access",
+                            description = "JWT Access Token (쿠키)",
+                            in = ParameterIn.COOKIE,
+                            required = true,
+                            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    ),
+                    @Parameter(
+                            name = "postId",
+                            in = ParameterIn.PATH,
+                            description = "게시물 ID",
+                            required = true,
+                            example = "1"
+                    )
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "조회 성공",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "커뮤니티 글 조회 응답 예시",
+                                    value = """
+                                            {
+                                            	"title":"오늘의 승리는 LG",
+                                            	"date":"2025-03-20T00:00:00",
+                                            	"writerNickname":"안타날릴",
+                                            	"writerProfileImage":["profile.png"],
+                                            	"activated":"true",
+                                            	"image":["image.png"],
+                                            	"content":"오늘은 LG가 이겨서 너무 행복합니다.",
+                                            	"comments":[
+                                            		"writerNickname":"난리나리라",
+                                            		"writerProfileImage":["profiles.png"],
+                                            		"activated":"true",
+                                            		"content":"홈런터질때 정말 짜릿했어요",
+                                            		"reComments":[
+                                            			"writerNickname":"테스형",
+                                            			"writerProfileImage":["profile_11.png"],
+                                            			"activated":"true",
+                                            			"content":"인정입니다."
+                                            		]
+                                            	]
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "게시물 ID가 1 미만일 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 400,
+                                              "status": "BAD_REQUEST",
+                                              "message": "게시물 ID는 1 이상이여야 합니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "인증 실패",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 401,
+                                              "status": "UNAUTHORIZED",
+                                              "message": "유효하지 않은 토큰입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "게시물 ID로 게시물을 찾을 수 없는 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 404,
+                                              "status": "NOT_FOUND",
+                                              "message": "게시물이 존재하지 않습니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 500,
+                                              "status": "INTERNAL_SERVER_ERROR",
+                                              "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<PostGetResponse> getPost(@PathVariable("postId") Long postId,
+                                            JwtUser user);
+
+    @Tag(name = "Get", description = "커뮤니티 글 목록 조회 API")
+    @Operation(
+            summary = "팀별 커뮤니티 글 목록 조회",
+            description = "특정 구단 이름을 기준으로 게시글 목록을 조회합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "Access",
+                            description = "JWT Access Token (쿠키)",
+                            in = ParameterIn.COOKIE,
+                            required = true,
+                            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    ),
+                    @Parameter(
+                            name = "teamName",
+                            description = "구단 이름",
+                            in = ParameterIn.PATH,
+                            required = true,
+                            example = "LG"
+                    ),
+                    @Parameter(
+                            name = "page",
+                            description = "페이지 번호 (0부터 시작)",
+                            in = ParameterIn.QUERY,
+                            required = false,
+                            example = "0"
+                    ),
+                    @Parameter(
+                            name = "size",
+                            description = "페이지 크기 (기본 10개)",
+                            in = ParameterIn.QUERY,
+                            required = false,
+                            example = "10"
+                    )
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "조회 성공",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "커뮤니티 글 목록 예시",
+                                    value = """
+                                        [
+                                            {
+                                                "postId": 1,
+                                                "title": "오늘 경기 어땠나요?",
+                                                "writerNickname": "LG팬",
+                                                "createdDate": "2025-05-20",
+                                                "image": ["LG.png"]
+                                            },
+                                            {
+                                                "postId": 2,
+                                                "title": "직관팟 모집",
+                                                "writerNickname": "야구사랑",
+                                                "createdDate": "2025-05-19",
+                                                "image": ["boll.jpg"]
+                                            }
+                                        ]
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "Enum 외 값 전달 시",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                            "code": 400,
+                                            "status": "BAD_REQUEST",
+                                            "message": "존재하지 않는 구단입니다."
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "인증 실패",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 401,
+                                              "status": "UNAUTHORIZED",
+                                              "message": "유효하지 않은 토큰입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 500,
+                                              "status": "INTERNAL_SERVER_ERROR",
+                                              "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<List<PostListResponse>> getPostsByTeam(@PathVariable("teamName") TeamTag teamName,
+                                                          @RequestParam(defaultValue = "0") int page,
+                                                          @RequestParam(defaultValue = "10") int size);
 }
+
 

--- a/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
@@ -417,16 +417,20 @@ public interface PostControllerSpecification {
                                             	"image":["image.png"],
                                             	"content":"오늘은 LG가 이겨서 너무 행복합니다.",
                                             	"comments":[
+                                            		{
                                             		"writerNickname":"난리나리라",
                                             		"writerProfileImage":["profiles.png"],
                                             		"activated":true,
                                             		"content":"홈런터질때 정말 짜릿했어요",
                                             		"reComments":[
+                                            			{
                                             			"writerNickname":"테스형",
                                             			"writerProfileImage":["profile_11.png"],
                                             			"activated":true,
                                             			"content":"인정입니다."
+                                            			}
                                             		]
+                                            		}
                                             	]
                                             }
                                             """
@@ -606,7 +610,7 @@ public interface PostControllerSpecification {
                     )
             )
     })
-    ResponseEntity<List<PostListResponse>> getPostsByTeam(@PathVariable("teamName") TeamTag teamName,
+    ResponseEntity<List<PostListResponse>> getPostsByTeam(@PathVariable("teamName") TeamTag teamName, JwtUser user,
                                                           @RequestParam(defaultValue = "0") int page,
                                                           @RequestParam(defaultValue = "10") int size);
 }

--- a/src/main/java/com/playus/communityservice/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/playus/communityservice/global/exception/ExceptionAdvice.java
@@ -28,6 +28,14 @@ public class ExceptionAdvice {
         return ErrorResponse.badRequestError(errorMessage);
     }
 
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ErrorResponse handleIllegalArgumentException(IllegalArgumentException e) {
+        String errorMessage = e.getMessage();
+        log.warn("IllegalArgumentException: {}", errorMessage);
+        return ErrorResponse.badRequestError(errorMessage);
+    }
+
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     @ExceptionHandler(ResponseStatusException.class)
     public ErrorResponse responseStatusExHandler(ResponseStatusException e) {


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
![image](https://github.com/user-attachments/assets/68cfd7f9-acdc-4eb2-9635-7afbd5af3f95)
직관 일지 Controller 생성

```
public PostCreateResponse createPost(PostCreateRequest request, JwtUser user, TeamTag tag) {
        if (request.isSecret()) {
            return createDiary(request, user, tag);
        } else {
            return createGeneralPost(request, user, tag);
        }
    }
```
위 코드를 통해 isSecret에 따라 직관일지와 일반 게시물 작성 구분

---

## 🔗 관련 이슈
- closes #33 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 라이브 매치 다이어리 작성 전용 엔드포인트가 추가되었습니다.
  - 게시글 작성 시 비밀글(다이어리) 여부를 선택할 수 있습니다.
  - 이미지 업로드를 위한 presigned URL 발급 기능이 추가되었습니다.
  - 특정 게시글 및 팀별 게시글 목록 조회 기능이 추가되었습니다.

- **버그 수정**
  - 게시글 생성, 수정 엔드포인트가 팀 태그를 경로에 포함하도록 변경되었습니다.

- **개선 사항**
  - 게시글, 댓글, 대댓글의 전문가 여부 필드명이 활성화 여부로 변경되었습니다.
  - 비밀글 작성 시 날짜 필수 입력 검증이 추가되었습니다.
  - 잘못된 요청에 대한 예외 처리 및 안내 메시지가 강화되었습니다.

- **문서화**
  - API 문서(Swagger/OpenAPI)가 상세하게 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->