### PR TITLE
Feat: 직관일지 API 구현

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
@@ -13,6 +13,7 @@ import com.playus.communityservice.domain.post.dto.post_view.PostListResponse;
 import com.playus.communityservice.domain.post.enums.TeamTag;
 import com.playus.communityservice.domain.post.service.PostReadOnlyService;
 import com.playus.communityservice.domain.post.service.PostService;
+import com.playus.communityservice.domain.post.specification.LiveMatchDiaryControllerSpecification;
 import com.playus.communityservice.global.jwt.JwtUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +27,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/live-match-diary")
 @RequiredArgsConstructor
-public class LiveMatchDiaryController {
+public class LiveMatchDiaryController implements LiveMatchDiaryControllerSpecification {
 
     private final PostService postService;
     private final PostReadOnlyService postReadOnlyService;
@@ -35,7 +36,7 @@ public class LiveMatchDiaryController {
     public ResponseEntity<PostCreateResponse> createPost(@PathVariable TeamTag tag,
                                                          @Valid @RequestBody PostCreateRequest request,
                                                          @AuthenticationPrincipal JwtUser user) {
-        PostCreateResponse response = postService.createPost(request, user, tag);
+        PostCreateResponse response = postService.createDiaryPost(request, user, tag);
         return ResponseEntity.ok(response);
     }
 
@@ -44,7 +45,15 @@ public class LiveMatchDiaryController {
                                                          @PathVariable Long postId,
                                                          @Valid @RequestBody PostUpdateRequest request,
                                                          @AuthenticationPrincipal JwtUser user) {
-        PostUpdateResponse response = postService.updatePost(request, postId, user, tag);
+        PostUpdateRequest updatedRequest = new PostUpdateRequest(
+                postId,
+                request.title(),
+                request.image(),
+                request.content(),
+                request.twpDate(),
+                request.isSecret()
+        );
+        PostUpdateResponse response = postService.updateDiaryPost(updatedRequest, user, tag);
         return ResponseEntity.ok(response);
     }
 
@@ -65,12 +74,13 @@ public class LiveMatchDiaryController {
 
     @GetMapping("/my")
     public ResponseEntity<List<DiaryListResponse>> getMyDiaries(
+            @RequestParam TeamTag teamName,
             @AuthenticationPrincipal JwtUser user,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam TeamTag tag
+            @RequestParam(defaultValue = "10") int size
+
     ) {
-        List<DiaryListResponse> response = postReadOnlyService.getMyDiaries(user, page, size, tag);
+        List<DiaryListResponse> response = postReadOnlyService.getMyDiaries(user, page, size, teamName);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
@@ -41,15 +41,17 @@ public class LiveMatchDiaryController {
 
     @PatchMapping("/{tag}/{postId}")
     public ResponseEntity<PostUpdateResponse> updatePost(@PathVariable TeamTag tag,
+                                                         @PathVariable Long postId,
                                                          @Valid @RequestBody PostUpdateRequest request,
                                                          @AuthenticationPrincipal JwtUser user) {
         PostUpdateResponse response = postService.updatePost(request, user, tag);
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("{postId}")
-    public ResponseEntity<PostDeleteResponse> deletePost(@Valid @RequestBody PostDeleteRequest request,
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<PostDeleteResponse> deletePost(@PathVariable Long postId,
                                                          @AuthenticationPrincipal JwtUser user) {
+        PostDeleteRequest request = new PostDeleteRequest(postId);
         PostDeleteResponse response = postService.deletePost(request, user);
         return ResponseEntity.ok(response);
     }
@@ -61,12 +63,12 @@ public class LiveMatchDiaryController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("my")
+    @GetMapping("/my")
     public ResponseEntity<List<DiaryListResponse>> getMyDiaries(
             @AuthenticationPrincipal JwtUser user,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
-            @PathVariable TeamTag tag
+            @RequestParam TeamTag tag
     ) {
         List<DiaryListResponse> response = postReadOnlyService.getMyDiaries(user, page, size, tag);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
@@ -44,7 +44,7 @@ public class LiveMatchDiaryController {
                                                          @PathVariable Long postId,
                                                          @Valid @RequestBody PostUpdateRequest request,
                                                          @AuthenticationPrincipal JwtUser user) {
-        PostUpdateResponse response = postService.updatePost(request, user, tag);
+        PostUpdateResponse response = postService.updatePost(request, postId, user, tag);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
@@ -1,8 +1,17 @@
 package com.playus.communityservice.domain.post.controller;
 
+import com.playus.communityservice.domain.post.dto.diary_view.DiaryGetResponse;
+import com.playus.communityservice.domain.post.dto.diary_view.DiaryListResponse;
 import com.playus.communityservice.domain.post.dto.post_create.PostCreateRequest;
 import com.playus.communityservice.domain.post.dto.post_create.PostCreateResponse;
+import com.playus.communityservice.domain.post.dto.post_delete.PostDeleteRequest;
+import com.playus.communityservice.domain.post.dto.post_delete.PostDeleteResponse;
+import com.playus.communityservice.domain.post.dto.post_update.PostUpdateRequest;
+import com.playus.communityservice.domain.post.dto.post_update.PostUpdateResponse;
+import com.playus.communityservice.domain.post.dto.post_view.PostGetResponse;
+import com.playus.communityservice.domain.post.dto.post_view.PostListResponse;
 import com.playus.communityservice.domain.post.enums.TeamTag;
+import com.playus.communityservice.domain.post.service.PostReadOnlyService;
 import com.playus.communityservice.domain.post.service.PostService;
 import com.playus.communityservice.global.jwt.JwtUser;
 import jakarta.validation.Valid;
@@ -12,6 +21,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/live-match-diary")
@@ -19,12 +29,46 @@ import java.net.URI;
 public class LiveMatchDiaryController {
 
     private final PostService postService;
+    private final PostReadOnlyService postReadOnlyService;
 
     @PostMapping("/{tag}")
     public ResponseEntity<PostCreateResponse> createPost(@PathVariable TeamTag tag,
                                                          @Valid @RequestBody PostCreateRequest request,
                                                          @AuthenticationPrincipal JwtUser user) {
         PostCreateResponse response = postService.createPost(request, user, tag);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{tag}/{postId}")
+    public ResponseEntity<PostUpdateResponse> updatePost(@PathVariable TeamTag tag,
+                                                         @Valid @RequestBody PostUpdateRequest request,
+                                                         @AuthenticationPrincipal JwtUser user) {
+        PostUpdateResponse response = postService.updatePost(request, user, tag);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("{postId}")
+    public ResponseEntity<PostDeleteResponse> deletePost(@Valid @RequestBody PostDeleteRequest request,
+                                                         @AuthenticationPrincipal JwtUser user) {
+        PostDeleteResponse response = postService.deletePost(request, user);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<DiaryGetResponse> getMyDiary(@PathVariable Long postId,
+                                                       @AuthenticationPrincipal JwtUser user) {
+        DiaryGetResponse response = postReadOnlyService.getMyDiary(postId, user);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("my")
+    public ResponseEntity<List<DiaryListResponse>> getMyDiaries(
+            @AuthenticationPrincipal JwtUser user,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @PathVariable TeamTag tag
+    ) {
+        List<DiaryListResponse> response = postReadOnlyService.getMyDiaries(user, page, size, tag);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
@@ -35,22 +35,31 @@ public class PostController implements PostControllerSpecification {
     public ResponseEntity<PostCreateResponse> createPost(@PathVariable TeamTag tag,
                                                      @Valid @RequestBody PostCreateRequest request,
                                                      @AuthenticationPrincipal JwtUser user) {
-        PostCreateResponse response = postService.createPost(request, user, tag);
+        PostCreateResponse response = postService.createGeneralPost(request, user, tag);
         return ResponseEntity.ok(response);
     }
 
-    @PatchMapping("/{tag}")
+    @PatchMapping("/{tag}/{postId}")
     public ResponseEntity<PostUpdateResponse> updatePost(@PathVariable TeamTag tag,
                                                          @PathVariable Long postId,
                                                          @Valid @RequestBody PostUpdateRequest request,
                                                          @AuthenticationPrincipal JwtUser user) {
-        PostUpdateResponse response = postService.updatePost(request, postId, user, tag);
+        PostUpdateRequest updatedRequest = new PostUpdateRequest(
+                postId,
+                request.title(),
+                request.image(),
+                request.content(),
+                request.twpDate(),
+                request.isSecret()
+        );
+        PostUpdateResponse response = postService.updateGeneralPost(updatedRequest, user, tag);
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping
-    public ResponseEntity<PostDeleteResponse> deletePost(@Valid @RequestBody PostDeleteRequest request,
+    @DeleteMapping("{postId}")
+    public ResponseEntity<PostDeleteResponse> deletePost(@PathVariable Long postId,
                                                      @AuthenticationPrincipal JwtUser user) {
+        PostDeleteRequest request = new PostDeleteRequest(postId);
         PostDeleteResponse response = postService.deletePost(request, user);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
@@ -1,7 +1,7 @@
 package com.playus.communityservice.domain.post.controller;
 
-import com.playus.communityservice.domain.post.dto.PostGetResponse;
-import com.playus.communityservice.domain.post.dto.PostListResponse;
+import com.playus.communityservice.domain.post.dto.post_view.PostGetResponse;
+import com.playus.communityservice.domain.post.dto.post_view.PostListResponse;
 import com.playus.communityservice.domain.post.dto.post_create.PostCreateRequest;
 import com.playus.communityservice.domain.post.dto.post_create.PostCreateResponse;
 import com.playus.communityservice.domain.post.dto.post_delete.PostDeleteRequest;
@@ -21,7 +21,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -37,7 +36,6 @@ public class PostController implements PostControllerSpecification {
                                                      @Valid @RequestBody PostCreateRequest request,
                                                      @AuthenticationPrincipal JwtUser user) {
         PostCreateResponse response = postService.createPost(request, user, tag);
-        URI location = URI.create("/post/" + response.postId());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
@@ -41,9 +41,10 @@ public class PostController implements PostControllerSpecification {
 
     @PatchMapping("/{tag}")
     public ResponseEntity<PostUpdateResponse> updatePost(@PathVariable TeamTag tag,
-                                                     @Valid @RequestBody PostUpdateRequest request,
-                                                     @AuthenticationPrincipal JwtUser user) {
-        PostUpdateResponse response = postService.updatePost(request, user, tag);
+                                                         @PathVariable Long postId,
+                                                         @Valid @RequestBody PostUpdateRequest request,
+                                                         @AuthenticationPrincipal JwtUser user) {
+        PostUpdateResponse response = postService.updatePost(request, postId, user, tag);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/playus/communityservice/domain/post/dto/diary_view/DiaryGetResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/post/dto/diary_view/DiaryGetResponse.java
@@ -1,0 +1,14 @@
+package com.playus.communityservice.domain.post.dto.diary_view;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record DiaryGetResponse(
+        String title,
+        LocalDate date,
+        String image,
+        String content
+) {
+}

--- a/src/main/java/com/playus/communityservice/domain/post/dto/diary_view/DiaryListResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/post/dto/diary_view/DiaryListResponse.java
@@ -1,0 +1,9 @@
+package com.playus.communityservice.domain.post.dto.diary_view;
+
+import java.time.LocalDate;
+
+public record DiaryListResponse(
+        String title,
+        String thumbnail,
+        LocalDate date
+) {}

--- a/src/main/java/com/playus/communityservice/domain/post/dto/post_update/PostUpdateRequest.java
+++ b/src/main/java/com/playus/communityservice/domain/post/dto/post_update/PostUpdateRequest.java
@@ -25,16 +25,19 @@ public record PostUpdateRequest(
         String content,
 
         @JsonFormat(pattern = "yyyy-MM-dd")
-        LocalDate twpDate
+        LocalDate twpDate,
+
+        boolean isSecret
 ) {
 
-    public static PostUpdateRequest of(Long postId, String title, String image, String content, LocalDate twpDate) {
+    public static PostUpdateRequest of(Long postId, String title, String image, String content, LocalDate twpDate, boolean isSecret) {
         return PostUpdateRequest.builder()
                 .postId(postId)
                 .title(title)
                 .image(image)
                 .content(content)
                 .twpDate(twpDate)
+                .isSecret(isSecret)
                 .build();
     }
 }

--- a/src/main/java/com/playus/communityservice/domain/post/dto/post_view/PostGetResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/post/dto/post_view/PostGetResponse.java
@@ -1,4 +1,4 @@
-package com.playus.communityservice.domain.post.dto;
+package com.playus.communityservice.domain.post.dto.post_view;
 
 import lombok.Builder;
 

--- a/src/main/java/com/playus/communityservice/domain/post/dto/post_view/PostListResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/post/dto/post_view/PostListResponse.java
@@ -1,4 +1,4 @@
-package com.playus.communityservice.domain.post.dto;
+package com.playus.communityservice.domain.post.dto.post_view;
 
 import java.time.LocalDate;
 

--- a/src/main/java/com/playus/communityservice/domain/post/repository/read/PostReadOnlyRepository.java
+++ b/src/main/java/com/playus/communityservice/domain/post/repository/read/PostReadOnlyRepository.java
@@ -10,6 +10,6 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import java.util.List;
 
 public interface PostReadOnlyRepository extends MongoRepository<PostDocument, Long> {
-    List<PostDocument> findAllByTag(TeamTag tag);
     Page<PostDocument> findAllByTag(TeamTag tag, Pageable pageable);
+    Page<PostDocument> findAllByWriterId(Long writerId, Pageable pageable);
 }

--- a/src/main/java/com/playus/communityservice/domain/post/repository/read/PostReadOnlyRepository.java
+++ b/src/main/java/com/playus/communityservice/domain/post/repository/read/PostReadOnlyRepository.java
@@ -11,5 +11,6 @@ import java.util.List;
 
 public interface PostReadOnlyRepository extends MongoRepository<PostDocument, Long> {
     Page<PostDocument> findAllByTag(TeamTag tag, Pageable pageable);
-    Page<PostDocument> findAllByWriterId(Long writerId, Pageable pageable);
+    Page<PostDocument> findAllByWriterIdAndTagAndIsSecretTrue(Long writerId, TeamTag tag, Pageable pageable);
+
 }

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -114,7 +114,7 @@ public class PostReadOnlyService {
 
     public List<DiaryListResponse> getMyDiaries(JwtUser user, int page, int size, TeamTag tag) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<PostDocument> postPage = postRepository.findAllByWriterId(user.getId(), pageable);
+        Page<PostDocument> postPage = postRepository.findAllByWriterIdAndTagAndIsSecretTrue(user.getId(), tag, pageable);
         List<PostDocument> posts = postPage.getContent();
 
         return posts.stream()

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -3,8 +3,10 @@ package com.playus.communityservice.domain.post.service;
 import com.playus.communityservice.domain.comment.document.CommentDocument;
 import com.playus.communityservice.domain.comment.repository.read.CommentReadOnlyRepository;
 import com.playus.communityservice.domain.post.document.PostDocument;
-import com.playus.communityservice.domain.post.dto.PostGetResponse;
-import com.playus.communityservice.domain.post.dto.PostListResponse;
+import com.playus.communityservice.domain.post.dto.diary_view.DiaryGetResponse;
+import com.playus.communityservice.domain.post.dto.diary_view.DiaryListResponse;
+import com.playus.communityservice.domain.post.dto.post_view.PostGetResponse;
+import com.playus.communityservice.domain.post.dto.post_view.PostListResponse;
 import com.playus.communityservice.domain.post.enums.TeamTag;
 import com.playus.communityservice.domain.post.repository.read.PostReadOnlyRepository;
 import com.playus.communityservice.global.exception.EntityNotFoundException;
@@ -76,6 +78,23 @@ public class PostReadOnlyService {
         );
     }
 
+    public DiaryGetResponse getMyDiary(Long postId, JwtUser user) {
+        PostDocument post = postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("직관일지"));
+
+        if (!post.isActivated() || !post.isSecret() || !post.getWriterId().equals(user.getId())) {
+            throw new EntityNotFoundException("직관일지");
+        }
+
+        return new DiaryGetResponse(
+                post.getTitle(),
+                post.getTwpDate(),
+                post.getImageUrl(),
+                post.getDescription()
+        );
+    }
+
+
     public List<PostListResponse> getPostsByTeam(TeamTag tag, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<PostDocument> postPage = postRepository.findAllByTag(tag, pageable);
@@ -89,6 +108,21 @@ public class PostReadOnlyService {
                         post.getTwpDate(),
                         getNickname(post.getWriterId()),
                         post.getImageUrl()
+                ))
+                .toList();
+    }
+
+    public List<DiaryListResponse> getMyDiaries(JwtUser user, int page, int size, TeamTag tag) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<PostDocument> postPage = postRepository.findAllByWriterId(user.getId(), pageable);
+        List<PostDocument> posts = postPage.getContent();
+
+        return posts.stream()
+                .filter(post -> post.isActivated() && post.isSecret())
+                .map(post -> new DiaryListResponse(
+                        post.getTitle(),
+                        post.getImageUrl(),
+                        post.getTwpDate()
                 ))
                 .toList();
     }

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -112,9 +112,9 @@ public class PostReadOnlyService {
                 .toList();
     }
 
-    public List<DiaryListResponse> getMyDiaries(JwtUser user, int page, int size, TeamTag tag) {
+    public List<DiaryListResponse> getMyDiaries(JwtUser user, int page, int size, TeamTag teamName) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<PostDocument> postPage = postRepository.findAllByWriterIdAndTagAndIsSecretTrue(user.getId(), tag, pageable);
+        Page<PostDocument> postPage = postRepository.findAllByWriterIdAndTagAndIsSecretTrue(user.getId(), teamName, pageable);
         List<PostDocument> posts = postPage.getContent();
 
         return posts.stream()

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
@@ -141,15 +141,13 @@ public class PostService {
                 .orElseThrow(() -> new EntityNotFoundException("게시글"));
 
         if (post.isSecret()) {
-            return deleteDiary(request, user);
+            return deleteDiary(post, user);
         } else {
-            return deleteGeneralPost(request, user);
+            return deleteGeneralPost(post, user);
         }
     }
 
-    public PostDeleteResponse deleteGeneralPost(PostDeleteRequest request, JwtUser user) {
-        Post post = postRepository.findById(request.postId())
-                .orElseThrow(() -> new EntityNotFoundException("게시글"));
+    private PostDeleteResponse deleteGeneralPost(Post post, JwtUser user) {
 
         if (!post.getWriterId().equals(user.getId())) {
             throw new ForbiddenAccessException("게시글");
@@ -169,10 +167,7 @@ public class PostService {
         return PostDeleteResponse.of(true, "게시물이 삭제되었습니다.");
     }
 
-    public PostDeleteResponse deleteDiary(PostDeleteRequest request, JwtUser user) {
-        Post post = postRepository.findById(request.postId())
-                .orElseThrow(() -> new EntityNotFoundException("직관일지"));
-
+    private PostDeleteResponse deleteDiary(Post post, JwtUser user) {
         if (!post.getWriterId().equals(user.getId())) {
             throw new ForbiddenAccessException("직관일지");
         }

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
@@ -76,8 +76,16 @@ public class PostService {
         return PostCreateResponse.of(diary.getId(), "직관일지 생성이 완료되었습니다.");
     }
 
-
     public PostUpdateResponse updatePost(PostUpdateRequest request, JwtUser user, TeamTag tag) {
+        if (request.isSecret()) {
+            return updateDiary(request, user, tag);
+        } else {
+            return updateGeneralPost(request, user, tag);
+        }
+    }
+
+
+    public PostUpdateResponse updateGeneralPost(PostUpdateRequest request, JwtUser user, TeamTag tag) {
         Post post = postRepository.findById(request.postId())
                 .orElseThrow(() -> new EntityNotFoundException("게시글"));
 
@@ -96,8 +104,50 @@ public class PostService {
         return PostUpdateResponse.of(true, "게시물이 수정되었습니다.");
     }
 
+    public PostUpdateResponse updateDiary(PostUpdateRequest request, JwtUser user, TeamTag tag) {
+        Post post = postRepository.findById(request.postId())
+                .orElseThrow(() -> new EntityNotFoundException("직관일지"));
+
+        if (!post.getWriterId().equals(user.getId())) {
+            throw new ForbiddenAccessException("직관일지");
+        }
+
+        if (request.twpDate() == null) {
+            throw new IllegalArgumentException("직관일지는 twpDate가 필수입니다.");
+        }
+
+        String currentImage = post.getImageUrl();
+        if (currentImage != null && !currentImage.isEmpty() &&
+                !currentImage.equals(request.image())) {
+            String fileName = currentImage.substring(currentImage.lastIndexOf("/") + 1);
+            s3Service.deleteImage(fileName);
+        }
+
+        post.updateAll(
+                request.title(),
+                request.content(),
+                tag,
+                true, // isSecret 유지
+                request.twpDate(),
+                request.image()
+        );
+
+        return PostUpdateResponse.of(true, "직관일지가 수정되었습니다.");
+    }
 
     public PostDeleteResponse deletePost(PostDeleteRequest request, JwtUser user) {
+        // DB 조회 후 isSecret 판단
+        Post post = postRepository.findById(request.postId())
+                .orElseThrow(() -> new EntityNotFoundException("게시글"));
+
+        if (post.isSecret()) {
+            return deleteDiary(request, user);
+        } else {
+            return deleteGeneralPost(request, user);
+        }
+    }
+
+    public PostDeleteResponse deleteGeneralPost(PostDeleteRequest request, JwtUser user) {
         Post post = postRepository.findById(request.postId())
                 .orElseThrow(() -> new EntityNotFoundException("게시글"));
 
@@ -118,6 +168,27 @@ public class PostService {
 
         return PostDeleteResponse.of(true, "게시물이 삭제되었습니다.");
     }
+
+    public PostDeleteResponse deleteDiary(PostDeleteRequest request, JwtUser user) {
+        Post post = postRepository.findById(request.postId())
+                .orElseThrow(() -> new EntityNotFoundException("직관일지"));
+
+        if (!post.getWriterId().equals(user.getId())) {
+            throw new ForbiddenAccessException("직관일지");
+        }
+
+        List<CommentGroup> commentGroups = commentGroupRepository.findAllByPost(post);
+        for (CommentGroup group : commentGroups) {
+            List<Comment> comments = commentRepository.findAllByCommentGroup(group);
+            comments.forEach(Comment::delete);
+            commentGroupRepository.delete(group);
+        }
+
+        post.delete();
+
+        return PostDeleteResponse.of(true, "직관일지가 삭제되었습니다.");
+    }
+
 
     public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(PresignedUrlForSaveImageRequest request) {
         return new PresignedUrlForSaveImageResponse(s3Service.generatePresignedUrl(request.imageFileName()));

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
@@ -76,16 +76,16 @@ public class PostService {
         return PostCreateResponse.of(diary.getId(), "직관일지 생성이 완료되었습니다.");
     }
 
-    public PostUpdateResponse updatePost(PostUpdateRequest request, JwtUser user, TeamTag tag) {
+    public PostUpdateResponse updatePost(PostUpdateRequest request, Long postId, JwtUser user, TeamTag tag) {
         if (request.isSecret()) {
-            return updateDiary(request, user, tag);
+            return updateDiary(request,postId, user, tag);
         } else {
-            return updateGeneralPost(request, user, tag);
+            return updateGeneralPost(request,postId, user, tag);
         }
     }
 
 
-    public PostUpdateResponse updateGeneralPost(PostUpdateRequest request, JwtUser user, TeamTag tag) {
+    public PostUpdateResponse updateGeneralPost(PostUpdateRequest request,Long postId, JwtUser user, TeamTag tag) {
         Post post = postRepository.findById(request.postId())
                 .orElseThrow(() -> new EntityNotFoundException("게시글"));
 
@@ -104,7 +104,7 @@ public class PostService {
         return PostUpdateResponse.of(true, "게시물이 수정되었습니다.");
     }
 
-    public PostUpdateResponse updateDiary(PostUpdateRequest request, JwtUser user, TeamTag tag) {
+    public PostUpdateResponse updateDiary(PostUpdateRequest request, Long postId, JwtUser user, TeamTag tag) {
         Post post = postRepository.findById(request.postId())
                 .orElseThrow(() -> new EntityNotFoundException("직관일지"));
 

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
@@ -36,15 +36,24 @@ public class PostService {
     private final CommentGroupRepository commentGroupRepository;
     private final CommentRepository commentRepository;
 
-    public PostCreateResponse createPost(PostCreateRequest request, JwtUser user, TeamTag tag) {
+    public PostCreateResponse createGeneralPost(PostCreateRequest request, JwtUser user, TeamTag tag) {
         if (request.isSecret()) {
-            return createDiary(request, user, tag);
-        } else {
-            return createGeneralPost(request, user, tag);
+            throw new IllegalArgumentException("일반 게시글 생성 API는 isSecret=false 여야 합니다.");
         }
+        return createPostInternal(request, user, tag, false);
     }
 
-    private PostCreateResponse createGeneralPost(PostCreateRequest request, JwtUser user, TeamTag tag) {
+    public PostCreateResponse createDiaryPost(PostCreateRequest request, JwtUser user, TeamTag tag) {
+        if (!request.isSecret()) {
+            throw new IllegalArgumentException("직관일지 생성 API는 isSecret=true 여야 합니다.");
+        }
+        if (request.twpDate() == null) {
+            throw new IllegalArgumentException("직관일지는 twpDate가 필수입니다.");
+        }
+        return createPostInternal(request, user, tag, true);
+    }
+
+    private PostCreateResponse createPostInternal(PostCreateRequest request, JwtUser user, TeamTag tag, boolean expectedIsSecret) {
         Post post = Post.create(
                 user.getId(),
                 request.title(),
@@ -52,73 +61,45 @@ public class PostService {
                 tag,
                 request.twpDate(),
                 request.image(),
-                false
+                expectedIsSecret
         );
         postRepository.save(post);
-        return PostCreateResponse.of(post.getId(), "게시물 생성이 완료되었습니다.");
-    }
 
-    private PostCreateResponse createDiary(PostCreateRequest request, JwtUser user, TeamTag tag) {
-        if (request.twpDate() == null) {
-            throw new IllegalArgumentException("직관일지는 twpDate가 필수입니다.");
-        }
-
-        Post diary = Post.create(
-                user.getId(),
-                request.title(),
-                request.content(),
-                tag,
-                request.twpDate(),
-                request.image(),
-                true
-        );
-        postRepository.save(diary);
-        return PostCreateResponse.of(diary.getId(), "직관일지 생성이 완료되었습니다.");
-    }
-
-    public PostUpdateResponse updatePost(PostUpdateRequest request, Long postId, JwtUser user, TeamTag tag) {
-        if (request.isSecret()) {
-            return updateDiary(request,postId, user, tag);
-        } else {
-            return updateGeneralPost(request,postId, user, tag);
-        }
+        String message = expectedIsSecret ? "직관일지 생성이 완료되었습니다." : "게시물 생성이 완료되었습니다.";
+        return PostCreateResponse.of(post.getId(), message);
     }
 
 
-    public PostUpdateResponse updateGeneralPost(PostUpdateRequest request,Long postId, JwtUser user, TeamTag tag) {
+    // PostController에서 호출
+    public PostUpdateResponse updateGeneralPost(PostUpdateRequest request, JwtUser user, TeamTag tag) {
+        return updatePostInternal(request, user, tag, false);
+    }
+
+    // LiveMatchDiaryController에서 호출
+    public PostUpdateResponse updateDiaryPost(PostUpdateRequest request, JwtUser user, TeamTag tag) {
+        return updatePostInternal(request, user, tag, true);
+    }
+
+    // 공통 로직 메서드
+    private PostUpdateResponse updatePostInternal(PostUpdateRequest request, JwtUser user, TeamTag tag, boolean expectedIsSecret) {
+
         Post post = postRepository.findById(request.postId())
-                .orElseThrow(() -> new EntityNotFoundException("게시글"));
+                .orElseThrow(() -> new EntityNotFoundException(expectedIsSecret ? "직관일지" : "게시글"));
+
+        if (post.isSecret() != expectedIsSecret) {
+            throw new IllegalArgumentException("잘못된 요청입니다. 엔드포인트를 확인해 주세요.");
+        }
 
         if (!post.getWriterId().equals(user.getId())) {
-            throw new ForbiddenAccessException("게시글");
+            throw new ForbiddenAccessException(expectedIsSecret ? "직관일지" : "게시글");
         }
 
-        String currentImage = post.getImageUrl();
-        if (currentImage != null && !currentImage.isEmpty() &&
-        !currentImage.equals(request.image())) {
-            String fileName = currentImage.substring(currentImage.lastIndexOf("/")+1);
-            s3Service.deleteImage(fileName);
-        }
-
-        post.updateAll(request.title(), request.content(), tag, false, request.twpDate(), request.image());
-        return PostUpdateResponse.of(true, "게시물이 수정되었습니다.");
-    }
-
-    public PostUpdateResponse updateDiary(PostUpdateRequest request, Long postId, JwtUser user, TeamTag tag) {
-        Post post = postRepository.findById(request.postId())
-                .orElseThrow(() -> new EntityNotFoundException("직관일지"));
-
-        if (!post.getWriterId().equals(user.getId())) {
-            throw new ForbiddenAccessException("직관일지");
-        }
-
-        if (request.twpDate() == null) {
+        if (expectedIsSecret && request.twpDate() == null) {
             throw new IllegalArgumentException("직관일지는 twpDate가 필수입니다.");
         }
 
         String currentImage = post.getImageUrl();
-        if (currentImage != null && !currentImage.isEmpty() &&
-                !currentImage.equals(request.image())) {
+        if (currentImage != null && !currentImage.isEmpty() && !currentImage.equals(request.image())) {
             String fileName = currentImage.substring(currentImage.lastIndexOf("/") + 1);
             s3Service.deleteImage(fileName);
         }
@@ -127,61 +108,34 @@ public class PostService {
                 request.title(),
                 request.content(),
                 tag,
-                true, // isSecret 유지
+                expectedIsSecret,
                 request.twpDate(),
                 request.image()
         );
 
-        return PostUpdateResponse.of(true, "직관일지가 수정되었습니다.");
+        return PostUpdateResponse.of(true, (expectedIsSecret ? "직관일지" : "게시글") + "이(가) 수정되었습니다.");
     }
+
 
     public PostDeleteResponse deletePost(PostDeleteRequest request, JwtUser user) {
-        // DB 조회 후 isSecret 판단
+
         Post post = postRepository.findById(request.postId())
-                .orElseThrow(() -> new EntityNotFoundException("게시글"));
+                .orElseThrow(() -> new EntityNotFoundException("해당글"));
 
-        if (post.isSecret()) {
-            return deleteDiary(post, user);
-        } else {
-            return deleteGeneralPost(post, user);
-        }
-    }
-
-    private PostDeleteResponse deleteGeneralPost(Post post, JwtUser user) {
+        String typeName = post.isSecret() ? "직관일지" : "게시글";
 
         if (!post.getWriterId().equals(user.getId())) {
-            throw new ForbiddenAccessException("게시글");
+            throw new ForbiddenAccessException(typeName);
         }
 
-        List<CommentGroup> commentGroups = commentGroupRepository.findAllByPost(post);
-
-        for (CommentGroup group : commentGroups) {
-
-            List<Comment> comments = commentRepository.findAllByCommentGroup(group);
-            comments.forEach(Comment::delete);
-
+        commentGroupRepository.findAllByPost(post).forEach(group -> {
+            commentRepository.findAllByCommentGroup(group).forEach(Comment::delete);
             commentGroupRepository.delete(group);
-        }
-        post.delete();
-
-        return PostDeleteResponse.of(true, "게시물이 삭제되었습니다.");
-    }
-
-    private PostDeleteResponse deleteDiary(Post post, JwtUser user) {
-        if (!post.getWriterId().equals(user.getId())) {
-            throw new ForbiddenAccessException("직관일지");
-        }
-
-        List<CommentGroup> commentGroups = commentGroupRepository.findAllByPost(post);
-        for (CommentGroup group : commentGroups) {
-            List<Comment> comments = commentRepository.findAllByCommentGroup(group);
-            comments.forEach(Comment::delete);
-            commentGroupRepository.delete(group);
-        }
+        });
 
         post.delete();
 
-        return PostDeleteResponse.of(true, "직관일지가 삭제되었습니다.");
+        return PostDeleteResponse.of(true, typeName + "이(가) 삭제되었습니다.");
     }
 
 

--- a/src/main/java/com/playus/communityservice/domain/post/specification/LiveMatchDiaryControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/LiveMatchDiaryControllerSpecification.java
@@ -183,7 +183,7 @@ public interface LiveMatchDiaryControllerSpecification {
                                     {
                                       "title": "비 오는 날에 만끽하는 승리",
                                       "image": ["post.jpg"],
-                                      "content": "우취될까봐 조마조마 했지만, 역시 KIA의 승!"
+                                      "content": "우취될까봐 조마조마 했지만, 역시 KIA의 승!",
                                       "twpDate" : "2025-05-01",
                                       "isSecret": true
                                     }
@@ -289,7 +289,7 @@ public interface LiveMatchDiaryControllerSpecification {
                                     name = "직관일지 조회 응답 예시",
                                     value = """
                                             {
-                                            	"team":"KIA"
+                                            	"team":"KIA",
                                              	"title":"아쉽게 패배한 날",
                                              	"date":"2025-03-20",
                                              	"image":["LG_vs_KIA.png"],
@@ -408,13 +408,13 @@ public interface LiveMatchDiaryControllerSpecification {
                                     value = """
                                         [
                                             {
-                                                "title":"비 오는 날에 만끽하는 승리"
+                                                "title":"비 오는 날에 만끽하는 승리",
                                                 "thumbnail":["post.jpg"],
                                                 "date":"2025-05-01",
                                                 "team":"KIA"
                                             },
                                             {
-                                                "title":"마지막 역전으로 이긴 날"
+                                                "title":"마지막 역전으로 이긴 날",
                                                 "thumbnail":["example.jpg"],
                                                 "date":"2025-03-20",
                                                 "team":"LG"

--- a/src/main/java/com/playus/communityservice/domain/post/specification/LiveMatchDiaryControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/LiveMatchDiaryControllerSpecification.java
@@ -1,5 +1,7 @@
 package com.playus.communityservice.domain.post.specification;
 
+import com.playus.communityservice.domain.post.dto.diary_view.DiaryGetResponse;
+import com.playus.communityservice.domain.post.dto.diary_view.DiaryListResponse;
 import com.playus.communityservice.domain.post.dto.post_view.PostGetResponse;
 import com.playus.communityservice.domain.post.dto.post_view.PostListResponse;
 import com.playus.communityservice.domain.post.dto.post_create.PostCreateRequest;
@@ -31,12 +33,12 @@ import java.util.List;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-public interface PostControllerSpecification {
+public interface LiveMatchDiaryControllerSpecification {
 
-    @Tag(name = "Post", description = "커뮤니티 글 작성 API")
+    @Tag(name = "Post", description = "직관일지 작성 API")
     @Operation(
-            summary = "커뮤니티 글 생성",
-            description = "커뮤니티 글을 작성합니다.",
+            summary = "직관일지 생성",
+            description = "직관일지를 작성합니다.",
             security = @SecurityRequirement(name = "AccessCookie"),
             parameters = @Parameter(
                     name = "Access",
@@ -50,12 +52,12 @@ public interface PostControllerSpecification {
                     content = @Content(
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
-                                    name = "커뮤니티 글 생성 요청 예시",
+                                    name = "직관일지 생성 요청 예시",
                                     value = """
                                     {
-                                      "title": "오늘 경기 재밌었어요!",
+                                      "title": "LG가 이긴 날",
                                       "image": ["post.jpg"],
-                                      "content": "LG가 이길 줄 알았죠!",
+                                      "content": "연장까지 가서 정말 숨죽이고 지켜봤던 날이었다.",
                                       "twpDate" : "2025-05-05"
                                     }
                                     """
@@ -69,18 +71,18 @@ public interface PostControllerSpecification {
                     content = @Content(
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
-                                    name = "커뮤니티 글 생성 응답 예시",
+                                    name = "직관일지 생성 응답 예시",
                                     value = """
                                     {
                                       "postId" : 1,
-                                      "message" : "게시글 생성이 완료되었습니다."
+                                      "message" : "직관일지 생성이 완료되었습니다."
                                     }
                                     """
                             )
                     )
             ),
             @ApiResponse(
-                    responseCode = "400", description = "게시글의 제목이 비어있을 때",
+                    responseCode = "400", description = "직관일지의 제목이 비어있을 때",
                     content = @Content(
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
@@ -88,14 +90,14 @@ public interface PostControllerSpecification {
                                             {
                                                 "code" : 400,
                                                 "statue" : "BAD_REQUEST"
-                                                "message" : "게시글의 제목이 비어있습니다!"
+                                                "message" : "직관일지의 제목이 비어있습니다!"
                                             }
                                             """
                             )
                     )
             ),
             @ApiResponse(
-                    responseCode = "400", description = "게시글의 내용이 비어있을 때",
+                    responseCode = "400", description = "직관일지의 내용이 비어있을 때",
                     content = @Content(
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
@@ -103,7 +105,7 @@ public interface PostControllerSpecification {
                                             {
                                                 "code" : 400,
                                                 "statue" : "BAD_REQUEST"
-                                                "message" : "게시글의 내용을 1~500자 이내로 작성해 주세요!"
+                                                "message" : "직관일지의 내용을 1~500자 이내로 작성해 주세요!"
                                             }
                                             """
                             )
@@ -111,18 +113,18 @@ public interface PostControllerSpecification {
             ),
     })
     ResponseEntity<PostCreateResponse> createPost(@PathVariable("tag") TeamTag tag,
-                                                  @Valid @Parameter(description = "게시글 생성 요청", required = true)
+                                                  @Valid @Parameter(description = "직관일지 생성 요청", required = true)
                                                   PostCreateRequest request, JwtUser user);
 
-    @Tag(name = "Post", description = "커뮤니티 글 삭제 API")
+    @Tag(name = "Post", description = "직관일지 삭제 API")
     @Operation(
-            summary = "커뮤니티 글 삭제",
-            description = "작성자가 커뮤니티 글을 삭제합니다.",
+            summary = "직관일지 삭제",
+            description = "작성자가 직관일지를 삭제합니다.",
             parameters = @Parameter(
                     name = "postId",
                     in = ParameterIn.PATH,
                     required = true,
-                    description = "삭제할 게시글 ID",
+                    description = "삭제할 직관일지 ID",
                     example = "1"
             )
     )
@@ -136,14 +138,14 @@ public interface PostControllerSpecification {
                                     value = """
                                     {
                                         "success" : true,
-                                        "message" : "게시물이 삭제되었습니다."
+                                        "message" : "직관일지가 삭제되었습니다."
                                     }
                                     """
                             )
                     )
             ),
             @ApiResponse(
-                    responseCode = "404", description = "해당 게시글을 찾을 수 없을 때",
+                    responseCode = "404", description = "해당 직관일지를 찾을 수 없을 때",
                     content = @Content(
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
@@ -151,39 +153,24 @@ public interface PostControllerSpecification {
                                             {
                                                 "code" : 404,
                                                 "statue" : "NOT_FOUND"
-                                                "message" : "해당 게시글을 찾을 수 없습니다."
+                                                "message" : "해당 직관일지를 찾을 수 없습니다."
                                             }
                                             """
                             )
                     )
-            ),
-            @ApiResponse(
-                    responseCode = "403", description = "해당 게시글의 작성자가 아닐 때",
-                    content = @Content(
-                            mediaType = APPLICATION_JSON_VALUE,
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                                "code" : 403,
-                                                "statue" : "FORBIDDEN"
-                                                "message" : "해당 게시글에 대한 권한이 없습니다."
-                                            }
-                                            """
-                            )
-                    )
-            ),
+            )
     })
     ResponseEntity<PostDeleteResponse> deletePost(@PathVariable("postId") Long postId, JwtUser user);
 
-    @Tag(name = "Post", description = "커뮤니티 글 수정 API")
+    @Tag(name = "Post", description = "직관일지 수정 API")
     @Operation(
-            summary = "커뮤니티 글 수정",
-            description = "작성자가 게시글을 수정합니다.",
+            summary = "직관일지 수정",
+            description = "작성자가 직관일지를 수정합니다.",
             parameters = @Parameter(
                     name = "postId",
                     in = ParameterIn.PATH,
                     required = true,
-                    description = "수정할 게시글 ID",
+                    description = "수정할 직관일지 ID",
                     example = "1"
             ),
             requestBody = @RequestBody(
@@ -191,14 +178,14 @@ public interface PostControllerSpecification {
                     content = @Content(
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
-                                    name = "게시글 수정 요청 예시",
+                                    name = "직관일지 수정 요청 예시",
                                     value = """
                                     {
-                                      "title": "오늘 경기 재밌었어요!",
+                                      "title": "비 오는 날에 만끽하는 승리",
                                       "image": ["post.jpg"],
-                                      "content": "긴장하면서 시청했네요."
+                                      "content": "우취될까봐 조마조마 했지만, 역시 KIA의 승!"
                                       "twpDate" : "2025-05-01",
-                                      "isSecret": false
+                                      "isSecret": true
                                     }
                                     """
                             )
@@ -215,14 +202,14 @@ public interface PostControllerSpecification {
                                     value = """
                                     {
                                         "success" : true,
-                                        "message" : "게시물이 수정되었습니다."
+                                        "message" : "직관일지가 수정되었습니다."
                                     }
                                     """
                             )
                     )
             ),
             @ApiResponse(
-                    responseCode = "404", description = "해당 게시글을 찾을 수 없을 때",
+                    responseCode = "404", description = "해당 직관일지를 찾을 수 없을 때",
                     content = @Content(
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
@@ -230,29 +217,14 @@ public interface PostControllerSpecification {
                                             {
                                                 "code" : 404,
                                                 "statue" : "NOT_FOUND"
-                                                "message" : "해당 게시글을 찾을 수 없습니다."
+                                                "message" : "해당 직관일지를 찾을 수 없습니다."
                                             }
                                             """
                             )
                     )
             ),
             @ApiResponse(
-                    responseCode = "403", description = "해당 게시글의 작성자가 아닐 때",
-                    content = @Content(
-                            mediaType = APPLICATION_JSON_VALUE,
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                                "code" : 403,
-                                                "statue" : "FORBIDDEN"
-                                                "message" : "해당 게시글에 대한 권한이 없습니다."
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400", description = "게시글의 제목이 비어있을 때",
+                    responseCode = "400", description = "직관일지의 제목이 비어있을 때",
                     content = @Content(
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
@@ -260,14 +232,14 @@ public interface PostControllerSpecification {
                                             {
                                                 "code" : 400,
                                                 "statue" : "BAD_REQUEST"
-                                                "message" : "게시글의 제목이 비어있습니다!"
+                                                "message" : "직관일지의 제목이 비어있습니다!"
                                             }
                                             """
                             )
                     )
             ),
             @ApiResponse(
-                    responseCode = "400", description = "게시글의 내용이 비어있을 때",
+                    responseCode = "400", description = "직관일지의 내용이 비어있을 때",
                     content = @Content(
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
@@ -275,7 +247,7 @@ public interface PostControllerSpecification {
                                             {
                                                 "code" : 400,
                                                 "statue" : "BAD_REQUEST"
-                                                "message" : "게시글의 내용을 1~500자 이내로 작성해 주세요!"
+                                                "message" : "직관일지의 내용을 1~500자 이내로 작성해 주세요!"
                                             }
                                             """
                             )
@@ -284,104 +256,13 @@ public interface PostControllerSpecification {
     })
     ResponseEntity<PostUpdateResponse> updatePost(@PathVariable("tag") TeamTag tag,
                                                   @PathVariable("postId") Long postId,
-                                                  @Valid @Parameter(description = "게시글 생성 요청", required = true)
+                                                  @Valid @Parameter(description = "직관일지 생성 요청", required = true)
                                                   PostUpdateRequest request, JwtUser user);
 
-    @Tag(name = "Post", description = "Presigned URL 발급 API")
+    @Tag(name = "Get", description = "직관일지 조회")
     @Operation(
-            summary = "Presigned URL 발급",
-            description = "프론트에서 이미지를 직접 저장하기 위한 Presigned URL을 생성 및 반환합니다. (버킷에 저장할 때는 PUT으로)",
-            security = @SecurityRequirement(name = "Access"),
-            parameters = @Parameter(
-                    name = "Access",
-                    description = "JWT Access Token (쿠키)",
-                    in = ParameterIn.COOKIE,
-                    required = true,
-                    example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-            ),
-            requestBody = @RequestBody(
-                    required = true,
-                    content = @Content(
-                            mediaType = APPLICATION_JSON_VALUE,
-                            examples = @ExampleObject(
-                                    name = "Presigned URL 발급 요청 예시",
-                                    value = """
-                                            {
-                                              "imageFileName": "party_thumbnail.jpg"
-                                            }
-                                            """
-                            )
-                    )
-            )
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200", description = "발급 성공",
-                    content = @Content(
-                            mediaType = APPLICATION_JSON_VALUE,
-                            examples = @ExampleObject(
-                                    name = "Presigned URL 발급 응답 예시",
-                                    value = """
-                                            {
-                                              "presignedUrl": "http://presigned-url.com"
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400", description = "이미지 파일명이 비어있을 경우 발생",
-                    content = @Content(
-                            mediaType = APPLICATION_JSON_VALUE,
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                              "code": 400,
-                                              "status": "BAD_REQUEST",
-                                              "message": "이미지 파일명은 필수입니다!"
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "401", description = "인증 실패",
-                    content = @Content(
-                            mediaType = APPLICATION_JSON_VALUE,
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                              "code": 401,
-                                              "status": "UNAUTHORIZED",
-                                              "message": "유효하지 않은 토큰입니다."
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(
-                            mediaType = APPLICATION_JSON_VALUE,
-                            examples = @ExampleObject(
-                                    value = """
-                                            {
-                                              "code": 500,
-                                              "status": "INTERNAL_SERVER_ERROR",
-                                              "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
-                                            }
-                                            """
-                            )
-                    )
-            )
-    })
-    PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(@Valid @Parameter(description = "Presigned URL 발급 요청", required = true)
-                                                                      PresignedUrlForSaveImageRequest request);
-
-    @Tag(name = "Get", description = "커뮤니티 글 조회")
-    @Operation(
-            summary = "커뮤니티 글 조회 API",
-            description = "특정 게시물에 대한 자세한 정보를 조회합니다.",
+            summary = "직관일지 조회 API",
+            description = "특정 직관일지에 대한 자세한 정보를 조회합니다.",
             parameters = {
                     @Parameter(
                             name = "Access",
@@ -393,7 +274,7 @@ public interface PostControllerSpecification {
                     @Parameter(
                             name = "postId",
                             in = ParameterIn.PATH,
-                            description = "게시물 ID",
+                            description = "직관일지 ID",
                             required = true,
                             example = "1"
                     )
@@ -405,39 +286,21 @@ public interface PostControllerSpecification {
                     content = @Content(
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
-                                    name = "커뮤니티 글 조회 응답 예시",
+                                    name = "직관일지 조회 응답 예시",
                                     value = """
                                             {
-                                            	"title":"오늘의 승리는 LG",
-                                            	"date":"2025-03-20T00:00:00",
-                                            	"writerNickname":"안타날릴",
-                                            	"writerProfileImage":["profile.png"],
-                                            	"activated":true,
-                                            	"image":["image.png"],
-                                            	"content":"오늘은 LG가 이겨서 너무 행복합니다.",
-                                            	"comments":[
-                                            		{
-                                            		"writerNickname":"난리나리라",
-                                            		"writerProfileImage":["profiles.png"],
-                                            		"activated":true,
-                                            		"content":"홈런터질때 정말 짜릿했어요",
-                                            		"reComments":[
-                                            			{
-                                            			"writerNickname":"테스형",
-                                            			"writerProfileImage":["profile_11.png"],
-                                            			"activated":true,
-                                            			"content":"인정입니다."
-                                            			}
-                                            		]
-                                            		}
-                                            	]
+                                            	"team":"KIA"
+                                             	"title":"아쉽게 패배한 날",
+                                             	"date":"2025-03-20",
+                                             	"image":["LG_vs_KIA.png"],
+                                             	"content":"마지막에 1점 차이로 역전을 당한 날..."
                                             }
                                             """
                             )
                     )
             ),
             @ApiResponse(
-                    responseCode = "400", description = "게시물 ID가 1 미만일 경우 발생",
+                    responseCode = "400", description = "postID가 1 미만일 경우 발생",
                     content = @Content(
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
@@ -445,7 +308,7 @@ public interface PostControllerSpecification {
                                             {
                                               "code": 400,
                                               "status": "BAD_REQUEST",
-                                              "message": "게시물 ID는 1 이상이여야 합니다!"
+                                              "message": "postID는 1 이상이여야 합니다!"
                                             }
                                             """
                             )
@@ -467,7 +330,7 @@ public interface PostControllerSpecification {
                     )
             ),
             @ApiResponse(
-                    responseCode = "404", description = "게시물 ID로 게시물을 찾을 수 없는 경우 발생",
+                    responseCode = "404", description = "postID로 직관일지를 찾을 수 없는 경우 발생",
                     content = @Content(
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
@@ -475,7 +338,7 @@ public interface PostControllerSpecification {
                                             {
                                               "code": 404,
                                               "status": "NOT_FOUND",
-                                              "message": "게시물이 존재하지 않습니다!"
+                                              "message": "직관일지가 존재하지 않습니다!"
                                             }
                                             """
                             )
@@ -497,13 +360,13 @@ public interface PostControllerSpecification {
                     )
             )
     })
-    ResponseEntity<PostGetResponse> getPost(@PathVariable("postId") Long postId,
-                                            JwtUser user);
+    ResponseEntity<DiaryGetResponse> getMyDiary(@PathVariable("postId") Long postId,
+                                                JwtUser user);
 
-    @Tag(name = "Get", description = "커뮤니티 글 목록 조회 API")
+    @Tag(name = "Get", description = "나의 직관일지 목록 조회 API")
     @Operation(
-            summary = "팀별 커뮤니티 글 목록 조회",
-            description = "특정 구단 이름을 기준으로 게시글 목록을 조회합니다.",
+            summary = "나의 직관일지 목록 조회",
+            description = "나의 직관일지 목록을 조회합니다.",
             parameters = {
                     @Parameter(
                             name = "Access",
@@ -545,18 +408,16 @@ public interface PostControllerSpecification {
                                     value = """
                                         [
                                             {
-                                                "postId": 1,
-                                                "title": "오늘 경기 어땠나요?",
-                                                "writerNickname": "LG팬",
-                                                "createdDate": "2025-05-20",
-                                                "image": ["LG.png"]
+                                                "title":"비 오는 날에 만끽하는 승리"
+                                                "thumbnail":["post.jpg"],
+                                                "date":"2025-05-01",
+                                                "team":"KIA"
                                             },
                                             {
-                                                "postId": 2,
-                                                "title": "직관팟 모집",
-                                                "writerNickname": "야구사랑",
-                                                "createdDate": "2025-05-19",
-                                                "image": ["boll.jpg"]
+                                                "title":"마지막 역전으로 이긴 날"
+                                                "thumbnail":["example.jpg"],
+                                                "date":"2025-03-20",
+                                                "team":"LG"
                                             }
                                         ]
                                         """
@@ -609,9 +470,9 @@ public interface PostControllerSpecification {
                     )
             )
     })
-    ResponseEntity<List<PostListResponse>> getPostsByTeam(@PathVariable("teamName") TeamTag teamName, JwtUser user,
-                                                          @RequestParam(defaultValue = "0") int page,
-                                                          @RequestParam(defaultValue = "10") int size);
+    ResponseEntity<List<DiaryListResponse>> getMyDiaries(@PathVariable("teamName") TeamTag teamName, JwtUser user,
+                                                         @RequestParam(defaultValue = "0") int page,
+                                                         @RequestParam(defaultValue = "10") int size);
 }
 
 

--- a/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
@@ -284,6 +284,7 @@ public interface PostControllerSpecification {
             ),
     })
     ResponseEntity<PostUpdateResponse> updatePost(@PathVariable("tag") TeamTag tag,
+                                                  @PathVariable Long postId,
                                                   @Valid @Parameter(description = "게시글 생성 요청", required = true)
                                                   PostUpdateRequest request, JwtUser user);
 

--- a/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
@@ -1,7 +1,7 @@
 package com.playus.communityservice.domain.post.specification;
 
-import com.playus.communityservice.domain.post.dto.PostGetResponse;
-import com.playus.communityservice.domain.post.dto.PostListResponse;
+import com.playus.communityservice.domain.post.dto.post_view.PostGetResponse;
+import com.playus.communityservice.domain.post.dto.post_view.PostListResponse;
 import com.playus.communityservice.domain.post.dto.post_create.PostCreateRequest;
 import com.playus.communityservice.domain.post.dto.post_create.PostCreateResponse;
 import com.playus.communityservice.domain.post.dto.post_delete.PostDeleteRequest;
@@ -24,7 +24,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 

--- a/src/main/java/com/playus/communityservice/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/playus/communityservice/global/config/security/SecurityConfig.java
@@ -25,14 +25,26 @@ public class SecurityConfig {
     private final JwtUtil jwtUtil;
     private final CorsConfigurationSource corsConfigurationSource;
 
+    private static final String [] INTERNAL_PATHS = {
+            "community/api/**",
+    };
+
     private String [] getWhiteList() {
         return new String[] {
+                "/error",
                 "/swagger",
                 "/swagger-ui.html",
                 "/swagger-ui/**",
+                "/webjars/**",
                 "/api-docs",
                 "/api-docs/**",
                 "/v3/api-docs/**",
+                "/oauth2/authorization/kakao",
+                "/login/oauth2/code/kakao",
+                "/oauth2/authorization/naver",
+                "/login/oauth2/code/naver",
+                "/api/v1/auth/reissue",
+                "/api/v1/auth/logout",
         };
     }
 
@@ -43,8 +55,13 @@ public class SecurityConfig {
         http.httpBasic(AbstractHttpConfigurer::disable);
         http.cors((httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer.configurationSource(corsConfigurationSource)));
         http.addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
+        // 인증/인가
         http.authorizeHttpRequests(auth -> auth
-                .requestMatchers(getWhiteList()).permitAll()
+                .requestMatchers(getWhiteList())
+                .permitAll()
+                .requestMatchers(INTERNAL_PATHS)
+                .permitAll()
                 .anyRequest().authenticated()
         );
 


### PR DESCRIPTION
1. 직관일지 수정 API 구현
2. 직관일지 삭제 API 구현
3. 나의 직관일지 조회 API 구현
4. 나의 직관일지 목록 조회 API 구현

## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
![image](https://github.com/user-attachments/assets/1254ad79-afc3-4782-b6be-2c6db4d2fef5)
직관일지 관련 Controller 코드입니다.

```
public PostUpdateResponse updatePost(PostUpdateRequest request, JwtUser user, TeamTag tag) {
        if (request.isSecret()) {
            return updateDiary(request, user, tag);
        } else {
            return updateGeneralPost(request, user, tag);
        }
    }
```
public PostDeleteResponse deletePost(PostDeleteRequest request, JwtUser user) {
        // DB 조회 후 isSecret 판단
        Post post = postRepository.findById(request.postId())
                .orElseThrow(() -> new EntityNotFoundException("게시글"));

        if (post.isSecret()) {
            return deleteDiary(request, user);
        } else {
            return deleteGeneralPost(request, user);
        }
    }
```
위처럼 isSecret을 통해 구분하였습니다.



---

## 🔗 관련 이슈
- closes #35 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 다이어리(비밀) 게시글 생성, 조회, 수정, 삭제를 위한 REST API가 추가되었습니다.
    - 내 다이어리 게시글 목록을 팀 태그와 페이지네이션으로 조회할 수 있습니다.
- **기능 개선**
    - 게시글 수정 시 비밀글 여부(isSecret)를 지정할 수 있습니다.
    - 게시글 생성, 수정, 삭제 로직이 일반 게시글과 비밀 다이어리 게시글로 명확히 분리되었습니다.
    - 게시글 수정 및 삭제 API 경로에 게시글 ID가 명시적으로 포함되어 호출 방식이 개선되었습니다.
    - 게시글 목록 및 상세 응답 구조가 다이어리와 일반 게시글로 구분되어 관리됩니다.
- **보안 및 설정**
    - 인증 예외 경로에 내부 API 및 OAuth2 콜백, 토큰 재발급, 로그아웃 경로가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->