### PR TITLE
Feat: 게시글 상세조회 시 tag 경로 추가

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
@@ -69,8 +69,9 @@ public class PostController implements PostControllerSpecification {
         return postService.generatePresignedUrlForSaveImage(request);
     }
 
-    @GetMapping("/{postId}")
-    public ResponseEntity<PostGetResponse> getPost(@PathVariable Long postId,
+    @GetMapping("/{tag}/{postId}")
+    public ResponseEntity<PostGetResponse> getPost(@PathVariable TeamTag tag,
+                                                   @PathVariable Long postId,
                                                    @AuthenticationPrincipal JwtUser user) {
         PostGetResponse response = postReadOnlyService.getPost(postId, user);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
@@ -500,7 +500,8 @@ public interface PostControllerSpecification {
                     )
             )
     })
-    ResponseEntity<PostGetResponse> getPost(@PathVariable("postId") Long postId,
+    ResponseEntity<PostGetResponse> getPost(@PathVariable("teamName") TeamTag teamName,
+                                            @PathVariable("postId") Long postId,
                                             JwtUser user);
 
     @Tag(name = "Get", description = "커뮤니티 글 목록 조회 API")


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
```
@GetMapping("/{tag}/{postId}")
    public ResponseEntity<PostGetResponse> getPost(@PathVariable TeamTag tag,
                                                   @PathVariable Long postId,
                                                   @AuthenticationPrincipal JwtUser user) {
        PostGetResponse response = postReadOnlyService.getPost(postId, user);
        return ResponseEntity.ok(response);
    }
```
기존 코드에서 위처럼 `@PathVariable TeamTag tag` 추가

---

## 🔗 관련 이슈
- closes #44 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 게시글 조회 시 URL에 팀 태그를 포함하도록 변경되었습니다. 이제 게시글을 조회할 때 팀 태그와 게시글 ID를 함께 입력해야 합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->