### PR TITLE
Chore: CORS 설정 추가

### DIFF
--- a/src/main/java/com/playus/communityservice/global/config/security/CorsConfig.java
+++ b/src/main/java/com/playus/communityservice/global/config/security/CorsConfig.java
@@ -2,27 +2,42 @@ package com.playus.communityservice.global.config.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import org.springframework.http.HttpMethod;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Collections;
 import java.util.List;
 
 @Configuration
 public class CorsConfig {
 
+    private static final List<String> ALLOWED_ORIGINS = List.of(
+            "https://web.playus.o-r.kr",
+            "https://api.playus.o-r.kr",
+            "http://localhost:3000"
+    );
+
     @Bean("corsConfigurationSource")
-    public org.springframework.web.cors.CorsConfigurationSource corsConfigurationSource() {
+    public CorsConfigurationSource corsConfigurationSource() {
+
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOrigins(List.of(
-                "*"
-        ));
-        configuration.addAllowedHeader("*");
-        configuration.addAllowedMethod("*");
+        configuration.setAllowedOrigins(ALLOWED_ORIGINS);
+        configuration.setAllowedHeaders(Collections.singletonList("*"));
+        configuration
+                .setAllowCredentials(true);
+        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
 
-        configuration.setAllowCredentials(true);
+        configuration.addAllowedMethod(HttpMethod.GET.name());
+        configuration.addAllowedMethod(HttpMethod.POST.name());
+        configuration.addAllowedMethod(HttpMethod.PUT.name());
+        configuration.addAllowedMethod(HttpMethod.DELETE.name());
+        configuration.addAllowedMethod(HttpMethod.OPTIONS.name());
 
-        org.springframework.web.cors.UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
     }


### PR DESCRIPTION
- 오리진 명시
- CORS credentials 설정 변경

## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
```
private static final List<String> ALLOWED_ORIGINS = List.of(
            "https://web.playus.o-r.kr",
            "https://api.playus.o-r.kr",
            "http://localhost:3000"
    );
```
오리진을 명시했습니다.

```
configuration
                .setAllowCredentials(true);
```
CORS credentials 설정을 true로 변경하였습니다.

---

## 🔗 관련 이슈
- closes #50 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - CORS 정책이 모든 오리진 허용에서 특정 세 개의 오리진만 허용하도록 변경되었습니다.
  - 허용되는 HTTP 메서드가 명확히 지정되어 보안성이 강화되었습니다.
  - "Authorization" 헤더가 노출되어 인증 관련 기능의 호환성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->