### PR TITLE
Refactor: 컨트롤러 HTTP 메서드 수정

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
@@ -37,7 +37,7 @@ public class LiveMatchDiaryController implements LiveMatchDiaryControllerSpecifi
         return ResponseEntity.ok(response);
     }
 
-    @PatchMapping("/{tag}/{postId}")
+    @PutMapping("/{tag}/{postId}")
     public ResponseEntity<PostUpdateResponse> updatePost(@PathVariable TeamTag tag,
                                                          @PathVariable Long postId,
                                                          @Valid @RequestBody PostUpdateRequest request,
@@ -54,7 +54,7 @@ public class LiveMatchDiaryController implements LiveMatchDiaryControllerSpecifi
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/{postId}")
+    @PatchMapping("/{postId}")
     public ResponseEntity<PostDeleteResponse> deletePost(@PathVariable Long postId,
                                                          @AuthenticationPrincipal JwtUser user) {
         PostDeleteRequest request = new PostDeleteRequest(postId);

--- a/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
@@ -39,7 +39,7 @@ public class PostController implements PostControllerSpecification {
         return ResponseEntity.ok(response);
     }
 
-    @PatchMapping("/{tag}/{postId}")
+    @PutMapping("/{tag}/{postId}")
     public ResponseEntity<PostUpdateResponse> updatePost(@PathVariable TeamTag tag,
                                                          @PathVariable Long postId,
                                                          @Valid @RequestBody PostUpdateRequest request,
@@ -56,7 +56,7 @@ public class PostController implements PostControllerSpecification {
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("{postId}")
+    @PatchMapping("{postId}")
     public ResponseEntity<PostDeleteResponse> deletePost(@PathVariable Long postId,
                                                      @AuthenticationPrincipal JwtUser user) {
         PostDeleteRequest request = new PostDeleteRequest(postId);

--- a/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
@@ -56,7 +56,7 @@ public class PostController implements PostControllerSpecification {
         return ResponseEntity.ok(response);
     }
 
-    @PatchMapping("{postId}")
+    @PatchMapping("/{postId}")
     public ResponseEntity<PostDeleteResponse> deletePost(@PathVariable Long postId,
                                                      @AuthenticationPrincipal JwtUser user) {
         PostDeleteRequest request = new PostDeleteRequest(postId);


### PR DESCRIPTION
1. 게시글/직관일지 수정시 @PatchMapping에서 @PutMapping으로 수정
2. 게시글/직관일지 삭제시 @DeleteMapping에서 @PatchMapping으로 수정

## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
컨트롤러에서 게시글/직관일지 수정에 `@PatchMapping`이던 http를 `@PutMapping`으로 변경하였습니다.

컨트롤러에서 게시글/직관일지 삭제에 `@DeleteMapping`이던 http를 `@PatchMapping`으로 변경하였습니다.

---

## 🔗 관련 이슈
- closes #52 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - 게시글 수정 엔드포인트의 HTTP 메서드가 PATCH에서 PUT으로 변경되어 전체 게시글 업데이트로 동작합니다.
  - 게시글 삭제 엔드포인트의 HTTP 메서드가 DELETE에서 PATCH로 변경되어 삭제가 직접적인 제거가 아닌 부분 업데이트로 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->