### PR TITLE
Cs 412 refactor/게시글 조회시 댓글도 조회하는 코드 수정

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/comment/document/CommentGroupDocument.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/document/CommentGroupDocument.java
@@ -6,6 +6,8 @@ import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.*;
 
+import java.util.Objects;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(value = "comment_group")
@@ -30,5 +32,16 @@ public class CommentGroupDocument {
                 .id(id)
                 .post(post)
                 .build();
+    }
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CommentGroupDocument that)) return false;
+        return this.id != null && this.id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/playus/communityservice/domain/comment/repository/read/CommentReadOnlyRepository.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/repository/read/CommentReadOnlyRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import java.util.List;
 
 public interface CommentReadOnlyRepository extends MongoRepository<CommentDocument, Long> {
-    List<CommentDocument> findAllByCommentGroup_Post(PostDocument post);
+    List<CommentDocument> findAllByCommentGroup_Post_Id(Long postId);
 }

--- a/src/main/java/com/playus/communityservice/domain/comment/specification/CommentControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/specification/CommentControllerSpecification.java
@@ -93,6 +93,13 @@ public interface CommentControllerSpecification {
     @Operation(
             summary = "커뮤니티 댓글 삭제",
             description = "작성자가 커뮤니티 댓글을 삭제합니다.",
+            parameters = @Parameter(
+                    name = "Access",
+                    description = "JWT access token (쿠키)",
+                    in = ParameterIn.COOKIE,
+                    required = true,
+                    example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            ),
             requestBody = @RequestBody(
                     required = true,
                     content = @Content(
@@ -164,6 +171,13 @@ public interface CommentControllerSpecification {
     @Operation(
             summary = "커뮤니티 댓글 수정",
             description = "작성자가 게시글을 수정합니다.",
+            parameters = @Parameter(
+                    name = "Access",
+                    description = "JWT access token (쿠키)",
+                    in = ParameterIn.COOKIE,
+                    required = true,
+                    example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            ),
             requestBody = @RequestBody(
                     required = true,
                     content = @Content(

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -38,7 +38,7 @@ public class PostReadOnlyService {
 
         post.increaseView();
 
-        List<CommentDocument> allComments = commentRepository.findAllByCommentGroup_Post(post);
+        List<CommentDocument> allComments = commentRepository.findAllByCommentGroup_Post_Id(post.getId());
 
         List<PostGetResponse.CommentDto> comments = allComments.stream()
                 .filter(c -> c.getCommentOrder() == 1L)

--- a/src/main/java/com/playus/communityservice/domain/post/specification/LiveMatchDiaryControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/LiveMatchDiaryControllerSpecification.java
@@ -116,13 +116,21 @@ public interface LiveMatchDiaryControllerSpecification {
     @Operation(
             summary = "직관일지 삭제",
             description = "작성자가 직관일지를 삭제합니다.",
-            parameters = @Parameter(
+            parameters = {
+                    @Parameter(
+                            name = "Access",
+                            description = "JWT access token (쿠키)",
+                            in = ParameterIn.COOKIE,
+                            required = true,
+                            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    ),
+                    @Parameter(
                     name = "postId",
                     in = ParameterIn.PATH,
                     required = true,
                     description = "삭제할 직관일지 ID",
                     example = "1"
-            )
+            )}
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -162,13 +170,21 @@ public interface LiveMatchDiaryControllerSpecification {
     @Operation(
             summary = "직관일지 수정",
             description = "작성자가 직관일지를 수정합니다.",
-            parameters = @Parameter(
+            parameters = {
+                    @Parameter(
+                            name = "Access",
+                            description = "JWT access token (쿠키)",
+                            in = ParameterIn.COOKIE,
+                            required = true,
+                            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    ),
+                    @Parameter(
                     name = "postId",
                     in = ParameterIn.PATH,
                     required = true,
                     description = "수정할 직관일지 ID",
                     example = "1"
-            ),
+            )},
             requestBody = @RequestBody(
                     required = true,
                     content = @Content(

--- a/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
@@ -119,13 +119,21 @@ public interface PostControllerSpecification {
     @Operation(
             summary = "커뮤니티 글 삭제",
             description = "작성자가 커뮤니티 글을 삭제합니다.",
-            parameters = @Parameter(
+            parameters = {
+                    @Parameter(
+                            name = "Access",
+                            description = "JWT access token (쿠키)",
+                            in = ParameterIn.COOKIE,
+                            required = true,
+                            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    ),
+                    @Parameter(
                     name = "postId",
                     in = ParameterIn.PATH,
                     required = true,
                     description = "삭제할 게시글 ID",
                     example = "1"
-            )
+            )}
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -180,13 +188,21 @@ public interface PostControllerSpecification {
     @Operation(
             summary = "커뮤니티 글 수정",
             description = "작성자가 게시글을 수정합니다.",
-            parameters = @Parameter(
+            parameters = {
+                    @Parameter(
+                            name = "Access",
+                            description = "JWT access token (쿠키)",
+                            in = ParameterIn.COOKIE,
+                            required = true,
+                            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    ),
+                    @Parameter(
                     name = "postId",
                     in = ParameterIn.PATH,
                     required = true,
                     description = "수정할 게시글 ID",
                     example = "1"
-            ),
+            )},
             requestBody = @RequestBody(
                     required = true,
                     content = @Content(


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
```
@Override
    public boolean equals(Object o) {
        if (this == o) return true;
        if (!(o instanceof CommentGroupDocument that)) return false;
        return this.id != null && this.id.equals(that.id);
    }

    @Override
    public int hashCode() {
        return Objects.hash(id);
    }
```
CommentGroupDocument 파일에 위 코드를 추가

`List<CommentDocument> findAllByCommentGroup_Post_Id(Long postId);`
post 자체가 아닌 ID를 조회하도록 수정

---

## 🔗 관련 이슈
- closes #56 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서화**
  - 댓글, 직관일지, 게시글 삭제 및 수정 API에 대해 JWT 액세스 토큰 쿠키("Access") 파라미터가 Swagger 문서에 명확하게 추가되어 인증 방식이 더 잘 안내됩니다.

- **버그 수정**
  - 댓글 조회 시 게시글 전체 객체가 아닌 게시글 ID로 조회하도록 개선되어 효율성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->