### PR TITLE
Refactor: 페이징 처리 삭제

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/LiveMatchDiaryController.java
@@ -72,12 +72,10 @@ public class LiveMatchDiaryController implements LiveMatchDiaryControllerSpecifi
 
     @GetMapping("/my")
     public ResponseEntity<List<DiaryListResponse>> getMyDiaries(
-            @AuthenticationPrincipal JwtUser user,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @AuthenticationPrincipal JwtUser user
 
     ) {
-        List<DiaryListResponse> response = postReadOnlyService.getMyDiaries(user, page, size);
+        List<DiaryListResponse> response = postReadOnlyService.getMyDiaries(user);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
@@ -80,11 +80,9 @@ public class PostController implements PostControllerSpecification {
     @GetMapping("/{teamName}")
     public ResponseEntity<List<PostListResponse>> getPostsByTeam(
             @PathVariable("teamName") TeamTag teamName,
-            @AuthenticationPrincipal JwtUser user,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @AuthenticationPrincipal JwtUser user
     ) {
-        List<PostListResponse> response = postReadOnlyService.getPostsByTeam(teamName, page, size);
+        List<PostListResponse> response = postReadOnlyService.getPostsByTeam(teamName);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/playus/communityservice/domain/post/repository/read/PostReadOnlyRepository.java
+++ b/src/main/java/com/playus/communityservice/domain/post/repository/read/PostReadOnlyRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import java.util.List;
 
 public interface PostReadOnlyRepository extends MongoRepository<PostDocument, Long> {
-    Page<PostDocument> findAllByTagAndIsSecretFalse(TeamTag tag, Pageable pageable);
-    Page<PostDocument> findAllByWriterIdAndIsSecretTrue(Long writerId, Pageable pageable);
+    List<PostDocument> findAllByTagAndIsSecretFalse(TeamTag tag);
+    List<PostDocument> findAllByWriterIdAndIsSecretTrue(Long writerId);
 
 }

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -95,10 +95,9 @@ public class PostReadOnlyService {
     }
 
 
-    public List<PostListResponse> getPostsByTeam(TeamTag tag, int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
-        Page<PostDocument> postPage = postRepository.findAllByTagAndIsSecretFalse(tag, pageable);
-        List<PostDocument> posts = postPage.getContent();
+    public List<PostListResponse> getPostsByTeam(TeamTag tag) {
+
+        List<PostDocument> posts = postRepository.findAllByTagAndIsSecretFalse(tag);
 
         return posts.stream()
                 .filter(PostDocument::isActivated)
@@ -112,10 +111,9 @@ public class PostReadOnlyService {
                 .toList();
     }
 
-    public List<DiaryListResponse> getMyDiaries(JwtUser user, int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
-        Page<PostDocument> postPage = postRepository.findAllByWriterIdAndIsSecretTrue(user.getId(), pageable);
-        List<PostDocument> posts = postPage.getContent();
+
+    public List<DiaryListResponse> getMyDiaries(JwtUser user) {
+        List<PostDocument> posts = postRepository.findAllByWriterIdAndIsSecretTrue(user.getId());
 
         return posts.stream()
                 .filter(post -> post.isActivated() && post.isSecret())
@@ -128,6 +126,7 @@ public class PostReadOnlyService {
                 ))
                 .toList();
     }
+
 
     private String getNickname(Long userId) {
         return "User#" + userId; // TODO: 유저 서비스 연동

--- a/src/main/java/com/playus/communityservice/domain/post/specification/LiveMatchDiaryControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/LiveMatchDiaryControllerSpecification.java
@@ -484,9 +484,7 @@ public interface LiveMatchDiaryControllerSpecification {
                     )
             )
     })
-    ResponseEntity<List<DiaryListResponse>> getMyDiaries(JwtUser user,
-                                                         @RequestParam(defaultValue = "0") int page,
-                                                         @RequestParam(defaultValue = "10") int size);
+    ResponseEntity<List<DiaryListResponse>> getMyDiaries(JwtUser user);
 }
 
 

--- a/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
@@ -430,7 +430,7 @@ public interface PostControllerSpecification {
                                             	"title":"오늘의 승리는 LG",
                                             	"date":"2025-03-20T00:00:00",
                                             	"writerNickname":"안타날릴",
-                                            	"writerProfileImage":["profile.png"],
+                                            	"writerProfileImage":"profile.png",
                                             	"activated":true,
                                             	"image":"image.png",
                                             	"content":"오늘은 LG가 이겨서 너무 행복합니다.",
@@ -629,9 +629,8 @@ public interface PostControllerSpecification {
                     )
             )
     })
-    ResponseEntity<List<PostListResponse>> getPostsByTeam(@PathVariable("teamName") TeamTag teamName, JwtUser user,
-                                                          @RequestParam(defaultValue = "0") int page,
-                                                          @RequestParam(defaultValue = "10") int size);
+    ResponseEntity<List<PostListResponse>> getPostsByTeam(@PathVariable("teamName") TeamTag teamName,
+                                                          JwtUser user);
 }
 
 


### PR DESCRIPTION
1. 내 직관일지 조회 API에서 페이지 처리(page, size) 삭제
2. 게시글 목록 조회 API에서 페이지 처리(page, size) 삭제

## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
```
Page<PostDocument> findAllByTagAndIsSecretFalse(TeamTag tag);
Page<PostDocument> findAllByWriterIdAndIsSecretTrue(Long writerId);
```
를 사용하던 코드를

```
List<PostDocument> findAllByTagAndIsSecretFalse(TeamTag tag);
List<PostDocument> findAllByWriterIdAndIsSecretTrue(Long writerId);
```
로 변경하여 페이징 처리를 삭제했습니다.

---

## 🔗 관련 이슈
- closes #58 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 커뮤니티 글 목록 및 다이어리 목록 조회 시 더 이상 페이지네이션 없이 전체 목록을 한 번에 확인할 수 있습니다.

- **Documentation**
	- 커뮤니티 글 조회 API 예시 응답에서 writerProfileImage 필드가 배열에서 문자열로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->