### PR TITLE
Feat: 다른 유저의 게시글 목록 조회 API

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
@@ -86,4 +86,10 @@ public class PostController implements PostControllerSpecification {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping("/writer/{writerId}")
+    public ResponseEntity<List<PostListResponse>> getPostsByWriter(@PathVariable Long writerId) {
+        List<PostListResponse> response = postReadOnlyService.getPostsByWriter(writerId);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
@@ -16,6 +16,7 @@ import com.playus.communityservice.domain.post.service.PostService;
 import com.playus.communityservice.domain.post.specification.PostControllerSpecification;
 import com.playus.communityservice.domain.common.security.JwtUser;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -87,7 +88,8 @@ public class PostController implements PostControllerSpecification {
     }
 
     @GetMapping("/writer/{writerId}")
-    public ResponseEntity<List<PostListResponse>> getPostsByWriter(@PathVariable Long writerId) {
+    public ResponseEntity<List<PostListResponse>> getPostsByWriter(@PathVariable @Min(1) Long writerId,
+                                                                   @AuthenticationPrincipal JwtUser user) {
         List<PostListResponse> response = postReadOnlyService.getPostsByWriter(writerId);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/playus/communityservice/domain/post/repository/read/PostReadOnlyRepository.java
+++ b/src/main/java/com/playus/communityservice/domain/post/repository/read/PostReadOnlyRepository.java
@@ -12,5 +12,5 @@ import java.util.List;
 public interface PostReadOnlyRepository extends MongoRepository<PostDocument, Long> {
     List<PostDocument> findAllByTagAndIsSecretFalse(TeamTag tag);
     List<PostDocument> findAllByWriterIdAndIsSecretTrue(Long writerId);
-
+    List<PostDocument> findAllByWriterIdAndIsSecretFalse(Long writerId);
 }

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -127,6 +127,21 @@ public class PostReadOnlyService {
                 .toList();
     }
 
+    public List<PostListResponse> getPostsByWriter(Long writerId) {
+        List<PostDocument> posts = postRepository.findAllByWriterIdAndIsSecretFalse(writerId);
+
+        return posts.stream()
+                .filter(PostDocument::isActivated)
+                .map(post -> new PostListResponse(
+                        post.getId(),
+                        post.getTitle(),
+                        post.getTwpDate(),
+                        getNickname(post.getWriterId()),
+                        post.getImageUrl()
+                ))
+                .toList();
+    }
+
 
     private String getNickname(Long userId) {
         return "User#" + userId; // TODO: 유저 서비스 연동

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.security.InvalidParameterException;
 import java.util.List;
 
 @Service
@@ -128,6 +129,10 @@ public class PostReadOnlyService {
     }
 
     public List<PostListResponse> getPostsByWriter(Long writerId) {
+        if (writerId == null || writerId <= 0) {
+            throw new InvalidParameterException("유효하지 않은 작성자 ID입니다.");
+        }
+
         List<PostDocument> posts = postRepository.findAllByWriterIdAndIsSecretFalse(writerId);
 
         return posts.stream()

--- a/src/main/java/com/playus/communityservice/domain/post/specification/LiveMatchDiaryControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/LiveMatchDiaryControllerSpecification.java
@@ -395,20 +395,6 @@ public interface LiveMatchDiaryControllerSpecification {
                             in = ParameterIn.PATH,
                             required = true,
                             example = "LG"
-                    ),
-                    @Parameter(
-                            name = "page",
-                            description = "페이지 번호 (0부터 시작)",
-                            in = ParameterIn.QUERY,
-                            required = false,
-                            example = "0"
-                    ),
-                    @Parameter(
-                            name = "size",
-                            description = "페이지 크기 (기본 10개)",
-                            in = ParameterIn.QUERY,
-                            required = false,
-                            example = "10"
                     )
             }
     )

--- a/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
@@ -648,19 +648,21 @@ public interface PostControllerSpecification {
                             examples = @ExampleObject(
                                     name = "다른 유저 게시글 목록 조회 응답 예시",
                                     value = """
-                                            {
-                                            	"postId" : 1,
-                                            	"title" : "오늘은 직관은 아니지만..."
-                                            	"twpDate" : "2025-06-03",
-                                            	"nickname" : "KSH"
-                                            	"image" : "KSH.png"
-                                            }
+                                            [
+                                                {
+                                            	    "postId" : 1,
+                                            	    "title" : "오늘은 직관은 아니지만..."
+                                            	    "twpDate" : "2025-06-03",
+                                            	    "nickname" : "KSH"
+                                            	    "image" : "KSH.png"
+                                                }
+                                            ]
                                             """
                             )
                     )
             ),
             @ApiResponse(
-                    responseCode = "400", description = "postID가 1 미만일 경우 발생",
+                    responseCode = "400", description = "writerID가 1 미만일 경우 발생",
                     content = @Content(
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
@@ -668,7 +670,7 @@ public interface PostControllerSpecification {
                                             {
                                               "code": 400,
                                               "status": "BAD_REQUEST",
-                                              "message": "postID는 1 이상이여야 합니다!"
+                                              "message": "writerID는 1 이상이여야 합니다!"
                                             }
                                             """
                             )
@@ -705,7 +707,8 @@ public interface PostControllerSpecification {
                     )
             )
     })
-    ResponseEntity<List<PostListResponse>> getPostsByWriter(@PathVariable("writerId") Long writerId);
+    ResponseEntity<List<PostListResponse>> getPostsByWriter(@PathVariable("writerId") Long writerId,
+                                                            JwtUser user);
 }
 
 

--- a/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
@@ -1,5 +1,6 @@
 package com.playus.communityservice.domain.post.specification;
 
+import com.playus.communityservice.domain.post.dto.diary_view.DiaryGetResponse;
 import com.playus.communityservice.domain.post.dto.post_view.PostGetResponse;
 import com.playus.communityservice.domain.post.dto.post_view.PostListResponse;
 import com.playus.communityservice.domain.post.dto.post_create.PostCreateRequest;
@@ -538,20 +539,6 @@ public interface PostControllerSpecification {
                             in = ParameterIn.PATH,
                             required = true,
                             example = "LG"
-                    ),
-                    @Parameter(
-                            name = "page",
-                            description = "페이지 번호 (0부터 시작)",
-                            in = ParameterIn.QUERY,
-                            required = false,
-                            example = "0"
-                    ),
-                    @Parameter(
-                            name = "size",
-                            description = "페이지 크기 (기본 10개)",
-                            in = ParameterIn.QUERY,
-                            required = false,
-                            example = "10"
                     )
             }
     )
@@ -631,6 +618,94 @@ public interface PostControllerSpecification {
     })
     ResponseEntity<List<PostListResponse>> getPostsByTeam(@PathVariable("teamName") TeamTag teamName,
                                                           JwtUser user);
+
+    @Tag(name = "Get", description = "다른 유저 게시글 조회")
+    @Operation(
+            summary = "다른 유저 게시글 조회",
+            description = "특정 유저가 작성한 게시글의 목록을 조회합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "Access",
+                            description = "JWT Access Token (쿠키)",
+                            in = ParameterIn.COOKIE,
+                            required = true,
+                            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    ),
+                    @Parameter(
+                            name = "writerId",
+                            in = ParameterIn.PATH,
+                            description = "유저 ID",
+                            required = true,
+                            example = "1"
+                    )
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "조회 성공",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "다른 유저 게시글 목록 조회 응답 예시",
+                                    value = """
+                                            {
+                                            	"postId" : 1,
+                                            	"title" : "오늘은 직관은 아니지만..."
+                                            	"twpDate" : "2025-06-03",
+                                            	"nickname" : "KSH"
+                                            	"image" : "KSH.png"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "postID가 1 미만일 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 400,
+                                              "status": "BAD_REQUEST",
+                                              "message": "postID는 1 이상이여야 합니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "인증 실패",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 401,
+                                              "status": "UNAUTHORIZED",
+                                              "message": "유효하지 않은 토큰입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 500,
+                                              "status": "INTERNAL_SERVER_ERROR",
+                                              "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<List<PostListResponse>> getPostsByWriter(@PathVariable("writerId") Long writerId);
 }
 
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
```
@GetMapping("/writer/{writerId}")
    public ResponseEntity<List<PostListResponse>> getPostsByWriter(@PathVariable Long writerId) {
        List<PostListResponse> response = postReadOnlyService.getPostsByWriter(writerId);
        return ResponseEntity.ok(response);
    }
```
위 API를 호출하는 Controller 코드입니다.

```
public List<PostListResponse> getPostsByWriter(Long writerId) {
        List<PostDocument> posts = postRepository.findAllByWriterIdAndIsSecretFalse(writerId);

        return posts.stream()
                .filter(PostDocument::isActivated)
                .map(post -> new PostListResponse(
                        post.getId(),
                        post.getTitle(),
                        post.getTwpDate(),
                        getNickname(post.getWriterId()),
                        post.getImageUrl()
                ))
                .toList();
    }
```
기본 게시글 목록 조회 API의 코드를 인용하여, WriterId에 따른 글 목록을 조회하도록 Service 코드를 구현하였습니다.

---

## 🔗 관련 이슈
- closes #60 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 특정 작성자의 공개 게시글 목록을 조회할 수 있는 엔드포인트가 추가되었습니다.
- **문서**
	- 일부 API의 Swagger 문서에서 페이지네이션 관련 쿼리 파라미터가 제거되었습니다.
	- 작성자별 게시글 조회 엔드포인트에 대한 API 명세가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->