### PR TITLE
Refactor: 글 목록 조회 중 twpDate -> createdAt으로 수정

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/post/document/PostDocument.java
+++ b/src/main/java/com/playus/communityservice/domain/post/document/PostDocument.java
@@ -3,10 +3,12 @@ package com.playus.communityservice.domain.post.document;
 import com.playus.communityservice.domain.post.enums.TeamTag;
 import jakarta.validation.constraints.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -45,6 +47,10 @@ public class PostDocument {
 
     @NotNull
     private int view;
+
+    @CreatedDate
+    @Field(name = "created_at")
+    private LocalDateTime createdAt;
 
 
     @Builder

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -40,7 +40,7 @@ public class PostReadOnlyService {
 
         post.increaseView();
 
-        List<CommentDocument> allComments = commentRepository.findAllByPostId(post.getId());
+        List<CommentDocument> allComments = commentRepository.findAllByCommentGroup_Post_Id(post.getId());
 
         List<PostGetResponse.CommentDto> comments = allComments.stream()
                 .filter(c -> c.getCommentOrder() == 1L)
@@ -107,7 +107,7 @@ public class PostReadOnlyService {
                 .map(post -> new PostListResponse(
                         post.getId(),
                         post.getTitle(),
-                        LocalDate.now(),
+                        post.getCreatedAt().toLocalDate(),
                         getNickname(post.getWriterId()),
                         post.getImageUrl()
                 ))
@@ -142,7 +142,7 @@ public class PostReadOnlyService {
                 .map(post -> new PostListResponse(
                         post.getId(),
                         post.getTitle(),
-                        LocalDate.now(),
+                        post.getCreatedAt().toLocalDate(),
                         getNickname(post.getWriterId()),
                         post.getImageUrl()
                 ))

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.security.InvalidParameterException;
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -39,13 +40,14 @@ public class PostReadOnlyService {
 
         post.increaseView();
 
-        List<CommentDocument> allComments = commentRepository.findAllByCommentGroup_Post_Id(post.getId());
+        List<CommentDocument> allComments = commentRepository.findAllByPostId(post.getId());
 
         List<PostGetResponse.CommentDto> comments = allComments.stream()
                 .filter(c -> c.getCommentOrder() == 1L)
                 .map(comment -> {
                     List<PostGetResponse.ReCommentDto> reComments = allComments.stream()
-                            .filter(reply -> reply.getCommentGroup().equals(comment.getCommentGroup()) && reply.getCommentOrder() > 1L)
+                            .filter(reply -> reply.getCommentGroup().getId().equals(comment.getCommentGroup().getId())
+                                    && reply.getCommentOrder() > 1L)
                             .map(reply -> new PostGetResponse.ReCommentDto(
                                     reply.getId(),
                                     getNickname(reply.getUserId()),
@@ -105,7 +107,7 @@ public class PostReadOnlyService {
                 .map(post -> new PostListResponse(
                         post.getId(),
                         post.getTitle(),
-                        post.getTwpDate(),
+                        LocalDate.now(),
                         getNickname(post.getWriterId()),
                         post.getImageUrl()
                 ))
@@ -140,7 +142,7 @@ public class PostReadOnlyService {
                 .map(post -> new PostListResponse(
                         post.getId(),
                         post.getTitle(),
-                        post.getTwpDate(),
+                        LocalDate.now(),
                         getNickname(post.getWriterId()),
                         post.getImageUrl()
                 ))


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
```
.map(post -> new PostListResponse(
                        post.getId(),
                        post.getTitle(),
                        LocalDate.now(),
                        getNickname(post.getWriterId()),
                        post.getImageUrl()
                ))
```
twpDate -> createdAt으로 수정

---

## 🔗 관련 이슈
- closes #62 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 댓글 및 답글 조회 방식이 개선되어, 댓글 목록과 답글이 더 정확하게 표시됩니다.

- **기타**
  - 팀별/작성자별 게시글 목록의 날짜 표기가 현재 생성일 기준으로 변경되었습니다.
  - 게시글 생성일 정보가 자동으로 기록되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->