### PR TITLE
Fix: 댓글 조회 안되는 오류 수정

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/comment/document/CommentDocument.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/document/CommentDocument.java
@@ -19,9 +19,8 @@ public class CommentDocument extends BaseTimeEntity {
     private Long userId;
 
     @NotNull
-    @DBRef(lazy = true)
     @Field(name = "comment_group_id")
-    private CommentGroupDocument commentGroup;
+    private Long commentGroupId;
 
     @NotNull
     @Field(name = "comment_order")
@@ -34,20 +33,20 @@ public class CommentDocument extends BaseTimeEntity {
     private boolean activated;
 
     @Builder
-    private CommentDocument(Long id, Long userId, CommentGroupDocument commentGroup, Long commentOrder, String content, boolean activated) {
+    private CommentDocument(Long id, Long userId, Long commentGroupId, Long commentOrder, String content, boolean activated) {
         this.id = id;
         this.userId = userId;
-        this.commentGroup = commentGroup;
+        this.commentGroupId = commentGroupId;
         this.commentOrder = commentOrder;
         this.content = content;
         this.activated = activated;
     }
 
-    public static CommentDocument createForOnlyTest(Long id, Long userId, CommentGroupDocument commentGroup, Long commentOrder, String content) {
+    public static CommentDocument createForOnlyTest(Long id, Long userId, Long commentGroupId, Long commentOrder, String content) {
         return CommentDocument.builder()
                 .id(id)
                 .userId(userId)
-                .commentGroup(commentGroup)
+                .commentGroupId(commentGroupId)
                 .commentOrder(commentOrder)
                 .content(content)
                 .activated(true)

--- a/src/main/java/com/playus/communityservice/domain/comment/document/CommentGroupDocument.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/document/CommentGroupDocument.java
@@ -17,20 +17,19 @@ public class CommentGroupDocument {
     private Long id;
 
     @NotNull
-    @DBRef(lazy = true)
     @Field(name = "post_id")
-    private PostDocument post;
+    private Long postId;
 
     @Builder
-    private CommentGroupDocument(Long id, PostDocument post) {
+    private CommentGroupDocument(Long id, Long postId) {
         this.id = id;
-        this.post = post;
+        this.postId = postId;
     }
 
-    public static CommentGroupDocument createForOnlyTest(Long id, PostDocument post) {
+    public static CommentGroupDocument createForOnlyTest(Long id, Long postId) {
         return CommentGroupDocument.builder()
                 .id(id)
-                .post(post)
+                .postId(postId)
                 .build();
     }
     @Override

--- a/src/main/java/com/playus/communityservice/domain/comment/repository/read/CommentGroupReadOnlyRepository.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/repository/read/CommentGroupReadOnlyRepository.java
@@ -1,0 +1,12 @@
+package com.playus.communityservice.domain.comment.repository.read;
+
+import com.playus.communityservice.domain.comment.document.CommentGroupDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+
+import java.util.List;
+
+public interface CommentGroupReadOnlyRepository extends MongoRepository<CommentGroupDocument, Long> {
+
+    List<CommentGroupDocument> findAllByPostId(Long postId);
+}

--- a/src/main/java/com/playus/communityservice/domain/comment/repository/read/CommentReadOnlyRepository.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/repository/read/CommentReadOnlyRepository.java
@@ -1,11 +1,13 @@
 package com.playus.communityservice.domain.comment.repository.read;
 
 import com.playus.communityservice.domain.comment.document.CommentDocument;
+import com.playus.communityservice.domain.comment.document.CommentGroupDocument;
+import com.playus.communityservice.domain.comment.entity.CommentGroup;
 import com.playus.communityservice.domain.post.document.PostDocument;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.List;
 
 public interface CommentReadOnlyRepository extends MongoRepository<CommentDocument, Long> {
-    List<CommentDocument> findAllByCommentGroup_Post_Id(Long postId);
+    List<CommentDocument> findAllByCommentGroupIdIn(List<Long> groupIds);
 }

--- a/src/main/java/com/playus/communityservice/domain/post/document/PostDocument.java
+++ b/src/main/java/com/playus/communityservice/domain/post/document/PostDocument.java
@@ -39,7 +39,7 @@ public class PostDocument {
     @Field(name = "is_secret")
     private boolean isSecret;
 
-    @Field(name = "jwp_date")
+    @Field(name = "twp_date")
     private LocalDate twpDate;
 
     @Field(name = "image_url")

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -1,7 +1,11 @@
 package com.playus.communityservice.domain.post.service;
 
 import com.playus.communityservice.domain.comment.document.CommentDocument;
+import com.playus.communityservice.domain.comment.document.CommentGroupDocument;
+import com.playus.communityservice.domain.comment.entity.CommentGroup;
+import com.playus.communityservice.domain.comment.repository.read.CommentGroupReadOnlyRepository;
 import com.playus.communityservice.domain.comment.repository.read.CommentReadOnlyRepository;
+import com.playus.communityservice.domain.comment.repository.write.CommentGroupRepository;
 import com.playus.communityservice.domain.post.document.PostDocument;
 import com.playus.communityservice.domain.post.dto.diary_view.DiaryGetResponse;
 import com.playus.communityservice.domain.post.dto.diary_view.DiaryListResponse;
@@ -29,6 +33,7 @@ public class PostReadOnlyService {
 
     private final PostReadOnlyRepository postRepository;
     private final CommentReadOnlyRepository commentRepository;
+    private final CommentGroupReadOnlyRepository commentGroupRepository;
 
     public PostGetResponse getPost(Long postId, JwtUser user) {
         PostDocument post = postRepository.findById(postId)
@@ -40,13 +45,22 @@ public class PostReadOnlyService {
 
         post.increaseView();
 
-        List<CommentDocument> allComments = commentRepository.findAllByCommentGroup_Post_Id(post.getId());
+        List<CommentGroupDocument> groups = commentGroupRepository.findAllByPostId(postId); // 엔티티 직접
+        System.out.println("Group count = " + groups.size());
+
+        List<Long> groupIds = groups.stream()
+                .map(CommentGroupDocument::getId)
+                .toList();
+
+        List<CommentDocument> allComments = commentRepository.findAllByCommentGroupIdIn(groupIds); // 객체 리스트로 조회
+        System.out.println("Comment count = " + allComments.size());
+
 
         List<PostGetResponse.CommentDto> comments = allComments.stream()
                 .filter(c -> c.getCommentOrder() == 1L)
                 .map(comment -> {
                     List<PostGetResponse.ReCommentDto> reComments = allComments.stream()
-                            .filter(reply -> reply.getCommentGroup().getId().equals(comment.getCommentGroup().getId())
+                            .filter(reply -> reply.getCommentGroupId().equals(comment.getCommentGroupId())
                                     && reply.getCommentOrder() > 1L)
                             .map(reply -> new PostGetResponse.ReCommentDto(
                                     reply.getId(),

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -2,10 +2,8 @@ package com.playus.communityservice.domain.post.service;
 
 import com.playus.communityservice.domain.comment.document.CommentDocument;
 import com.playus.communityservice.domain.comment.document.CommentGroupDocument;
-import com.playus.communityservice.domain.comment.entity.CommentGroup;
 import com.playus.communityservice.domain.comment.repository.read.CommentGroupReadOnlyRepository;
 import com.playus.communityservice.domain.comment.repository.read.CommentReadOnlyRepository;
-import com.playus.communityservice.domain.comment.repository.write.CommentGroupRepository;
 import com.playus.communityservice.domain.post.document.PostDocument;
 import com.playus.communityservice.domain.post.dto.diary_view.DiaryGetResponse;
 import com.playus.communityservice.domain.post.dto.diary_view.DiaryListResponse;
@@ -17,14 +15,11 @@ import com.playus.communityservice.global.exception.EntityNotFoundException;
 import com.playus.communityservice.domain.common.security.JwtUser;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.security.InvalidParameterException;
-import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -46,21 +41,19 @@ public class PostReadOnlyService {
         post.increaseView();
 
         List<CommentGroupDocument> groups = commentGroupRepository.findAllByPostId(postId); // 엔티티 직접
-        System.out.println("Group count = " + groups.size());
 
         List<Long> groupIds = groups.stream()
                 .map(CommentGroupDocument::getId)
                 .toList();
 
         List<CommentDocument> allComments = commentRepository.findAllByCommentGroupIdIn(groupIds); // 객체 리스트로 조회
-        System.out.println("Comment count = " + allComments.size());
 
 
         List<PostGetResponse.CommentDto> comments = allComments.stream()
                 .filter(c -> c.getCommentOrder() == 1L)
                 .map(comment -> {
                     List<PostGetResponse.ReCommentDto> reComments = allComments.stream()
-                            .filter(reply -> reply.getCommentGroupId().equals(comment.getCommentGroupId())
+                            .filter(reply -> Objects.equals(reply.getCommentGroupId(), comment.getCommentGroupId())
                                     && reply.getCommentOrder() > 1L)
                             .map(reply -> new PostGetResponse.ReCommentDto(
                                     reply.getId(),


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
```
@NotNull
    @Field(name = "comment_group_id")
    private Long commentGroupId;
```
Long으로 저장하도록 수정

```
List<CommentGroupDocument> groups = commentGroupRepository.findAllByPostId(postId); // 엔티티 직접
        System.out.println("Group count = " + groups.size());

        List<Long> groupIds = groups.stream()
                .map(CommentGroupDocument::getId)
                .toList();

        List<CommentDocument> allComments = commentRepository.findAllByCommentGroupIdIn(groupIds); // 객체 리스트로 조회
        System.out.println("Comment count = " + allComments.size());
```
해당 댓글/답글을 불러올 때, 과정을 나누도록 수정 


---

## 🔗 관련 이슈
- closes #64 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 게시글에 연결된 모든 댓글 그룹을 조회하는 기능이 추가되었습니다.

- **버그 수정**
	- 댓글 및 댓글 그룹 조회 방식이 개선되어, 게시글의 댓글을 더 정확하게 불러올 수 있습니다.

- **스타일**
	- 일부 필드의 데이터베이스 매핑명이 수정되었습니다. (예: twpDate 필드)

- **리팩터**
	- 댓글 및 댓글 그룹 관련 데이터 구조가 단순화되어 성능과 유지보수성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->