### PR TITLE
Cs 424 feat/id 기반 커뮤니티 글 조회 api 구현

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/comment/specification/CommentControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/specification/CommentControllerSpecification.java
@@ -93,13 +93,21 @@ public interface CommentControllerSpecification {
     @Operation(
             summary = "커뮤니티 댓글 삭제",
             description = "작성자가 커뮤니티 댓글을 삭제합니다.",
-            parameters = @Parameter(
+            parameters = {
+                    @Parameter(
                     name = "Access",
                     description = "JWT access token (쿠키)",
                     in = ParameterIn.COOKIE,
                     required = true,
                     example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
             ),
+                    @Parameter(
+                    name = "id",
+                    in = ParameterIn.PATH,
+                    required = true,
+                    description = "삭제할 댓글 ID",
+                    example = "1"
+            )},
             requestBody = @RequestBody(
                     required = true,
                     content = @Content(
@@ -108,7 +116,6 @@ public interface CommentControllerSpecification {
                                     name = "커뮤니티 댓글 삭제 요청 예시",
                                     value = """
                                             {
-                                                "commentId" : 1,
                                                 "commentGroupId" : 2
                                             }
                                             """
@@ -171,13 +178,21 @@ public interface CommentControllerSpecification {
     @Operation(
             summary = "커뮤니티 댓글 수정",
             description = "작성자가 게시글을 수정합니다.",
-            parameters = @Parameter(
-                    name = "Access",
-                    description = "JWT access token (쿠키)",
-                    in = ParameterIn.COOKIE,
-                    required = true,
-                    example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-            ),
+            parameters = {
+                    @Parameter(
+                            name = "Access",
+                            description = "JWT access token (쿠키)",
+                            in = ParameterIn.COOKIE,
+                            required = true,
+                            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    ),
+                    @Parameter(
+                            name = "id",
+                            in = ParameterIn.PATH,
+                            required = true,
+                            description = "수정할 댓글 ID",
+                            example = "1"
+                    )},
             requestBody = @RequestBody(
                     required = true,
                     content = @Content(
@@ -186,7 +201,6 @@ public interface CommentControllerSpecification {
                                     name = "댓글/답글 수정 요청 예시",
                                     value = """
                                             {
-                                                "commentId" : 1,
                                                 "commentGroupId" : 2,
                                                 "content" : "아슬아슬하게 이겼네요!"
                                             }

--- a/src/main/java/com/playus/communityservice/domain/comment/specification/CommentControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/specification/CommentControllerSpecification.java
@@ -102,7 +102,7 @@ public interface CommentControllerSpecification {
                     example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
             ),
                     @Parameter(
-                    name = "id",
+                    name = "commentId",
                     in = ParameterIn.PATH,
                     required = true,
                     description = "삭제할 댓글 ID",
@@ -187,7 +187,7 @@ public interface CommentControllerSpecification {
                             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                     ),
                     @Parameter(
-                            name = "id",
+                            name = "commentId",
                             in = ParameterIn.PATH,
                             required = true,
                             description = "수정할 댓글 ID",

--- a/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
@@ -78,6 +78,14 @@ public class PostController implements PostControllerSpecification {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping("/writer/{writerId}/{postId}")
+    public ResponseEntity<PostGetResponse> getPostById(@PathVariable Long writerId,
+                                                       @PathVariable Long postId,
+                                                       @AuthenticationPrincipal JwtUser user) {
+        PostGetResponse response = postReadOnlyService.getPostById(writerId, postId, user);
+        return ResponseEntity.ok(response);
+    }
+
     @GetMapping("/{teamName}")
     public ResponseEntity<List<PostListResponse>> getPostsByTeam(
             @PathVariable("teamName") TeamTag teamName,
@@ -88,7 +96,7 @@ public class PostController implements PostControllerSpecification {
     }
 
     @GetMapping("/writer/{writerId}")
-    public ResponseEntity<List<PostListResponse>> getPostsByWriter(@PathVariable @Min(1) Long writerId,
+    public ResponseEntity<List<PostListResponse>> getPostsByWriter(@PathVariable Long writerId,
                                                                    @AuthenticationPrincipal JwtUser user) {
         List<PostListResponse> response = postReadOnlyService.getPostsByWriter(writerId);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/playus/communityservice/domain/post/dto/post_view/PostGetResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/post/dto/post_view/PostGetResponse.java
@@ -1,5 +1,6 @@
 package com.playus.communityservice.domain.post.dto.post_view;
 
+import com.playus.communityservice.domain.post.enums.TeamTag;
 import lombok.Builder;
 
 import java.time.LocalDate;
@@ -8,11 +9,11 @@ import java.util.List;
 @Builder
 public record PostGetResponse(
         Long postId,
+        TeamTag tag,
         String title,
         LocalDate date,
         String writerNickname,
         String writerProfileImage,
-        boolean activated,
         String image,
         String content,
         List<CommentDto> comments
@@ -21,7 +22,6 @@ public record PostGetResponse(
             Long commentId,
             String writerNickname,
             String writerProfileImage,
-            boolean activated,
             String content,
             List<ReCommentDto> reComments
     ) {}
@@ -30,7 +30,6 @@ public record PostGetResponse(
             Long reCommentId,
             String writerNickname,
             String writerProfileImage,
-            boolean activated,
             String content
     ) {}
 }

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -59,7 +59,6 @@ public class PostReadOnlyService {
                                     reply.getId(),
                                     getNickname(reply.getUserId()),
                                     getProfileImage(reply.getUserId()),
-                                    isExpert(reply.getUserId()),
                                     reply.getContent()
                             ))
                             .toList();
@@ -68,7 +67,6 @@ public class PostReadOnlyService {
                             comment.getId(),
                             getNickname(comment.getUserId()),
                             getProfileImage(comment.getUserId()),
-                            isExpert(comment.getUserId()),
                             comment.getContent(),
                             reComments
                     );
@@ -77,11 +75,11 @@ public class PostReadOnlyService {
 
         return new PostGetResponse(
                 post.getId(),
+                post.getTag(),
                 post.getTitle(),
                 post.getTwpDate(),
                 getNickname(post.getWriterId()),
                 getProfileImage(post.getWriterId()),
-                isExpert(post.getWriterId()),
                 post.getImageUrl(),
                 post.getDescription(),
                 comments
@@ -156,6 +154,65 @@ public class PostReadOnlyService {
                 .toList();
     }
 
+    public PostGetResponse getPostById(Long writerId, Long postId, JwtUser user) {
+        PostDocument post = postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("게시글"));
+
+        if (!post.isActivated()) {
+            throw new EntityNotFoundException("게시글");
+        }
+
+        if (!post.getWriterId().equals(writerId)) {
+            throw new EntityNotFoundException("작성자와 게시글이 일치하지 않습니다.");
+        }
+
+        post.increaseView();
+
+        List<CommentGroupDocument> groups = commentGroupRepository.findAllByPostId(postId); // 엔티티 직접
+
+        List<Long> groupIds = groups.stream()
+                .map(CommentGroupDocument::getId)
+                .toList();
+
+        List<CommentDocument> allComments = commentRepository.findAllByCommentGroupIdIn(groupIds); // 객체 리스트로 조회
+
+
+        List<PostGetResponse.CommentDto> comments = allComments.stream()
+                .filter(c -> c.getCommentOrder() == 1L)
+                .map(comment -> {
+                    List<PostGetResponse.ReCommentDto> reComments = allComments.stream()
+                            .filter(reply -> Objects.equals(reply.getCommentGroupId(), comment.getCommentGroupId())
+                                    && reply.getCommentOrder() > 1L)
+                            .map(reply -> new PostGetResponse.ReCommentDto(
+                                    reply.getId(),
+                                    getNickname(reply.getUserId()),
+                                    getProfileImage(reply.getUserId()),
+                                    reply.getContent()
+                            ))
+                            .toList();
+
+                    return new PostGetResponse.CommentDto(
+                            comment.getId(),
+                            getNickname(comment.getUserId()),
+                            getProfileImage(comment.getUserId()),
+                            comment.getContent(),
+                            reComments
+                    );
+                })
+                .toList();
+
+        return new PostGetResponse(
+                post.getId(),
+                post.getTag(),
+                post.getTitle(),
+                post.getTwpDate(),
+                getNickname(post.getWriterId()),
+                getProfileImage(post.getWriterId()),
+                post.getImageUrl(),
+                post.getDescription(),
+                comments
+        );
+    }
 
     private String getNickname(Long userId) {
         return "User#" + userId; // TODO: 유저 서비스 연동

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -31,6 +31,14 @@ public class PostReadOnlyService {
     private final CommentGroupReadOnlyRepository commentGroupRepository;
 
     public PostGetResponse getPost(Long postId, JwtUser user) {
+        return buildPostGetResponse(postId, null);
+    }
+
+    public PostGetResponse getPostById(Long writerId, Long postId, JwtUser user) {
+        return buildPostGetResponse(postId, writerId);
+    }
+
+    private PostGetResponse buildPostGetResponse(Long postId, Long writerId) {
         PostDocument post = postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("게시글"));
 
@@ -38,16 +46,18 @@ public class PostReadOnlyService {
             throw new EntityNotFoundException("게시글");
         }
 
+        if (writerId != null && !post.getWriterId().equals(writerId)) {
+            throw new EntityNotFoundException("작성자와 게시글이 일치하지 않습니다.");
+        }
+
         post.increaseView();
 
-        List<CommentGroupDocument> groups = commentGroupRepository.findAllByPostId(postId); // 엔티티 직접
-
+        List<CommentGroupDocument> groups = commentGroupRepository.findAllByPostId(postId);
         List<Long> groupIds = groups.stream()
                 .map(CommentGroupDocument::getId)
                 .toList();
 
-        List<CommentDocument> allComments = commentRepository.findAllByCommentGroupIdIn(groupIds); // 객체 리스트로 조회
-
+        List<CommentDocument> allComments = commentRepository.findAllByCommentGroupIdIn(groupIds);
 
         List<PostGetResponse.CommentDto> comments = allComments.stream()
                 .filter(c -> c.getCommentOrder() == 1L)
@@ -85,6 +95,7 @@ public class PostReadOnlyService {
                 comments
         );
     }
+
 
     public DiaryGetResponse getMyDiary(Long postId, JwtUser user) {
         PostDocument post = postRepository.findById(postId)
@@ -152,66 +163,6 @@ public class PostReadOnlyService {
                         post.getImageUrl()
                 ))
                 .toList();
-    }
-
-    public PostGetResponse getPostById(Long writerId, Long postId, JwtUser user) {
-        PostDocument post = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("게시글"));
-
-        if (!post.isActivated()) {
-            throw new EntityNotFoundException("게시글");
-        }
-
-        if (!post.getWriterId().equals(writerId)) {
-            throw new EntityNotFoundException("작성자와 게시글이 일치하지 않습니다.");
-        }
-
-        post.increaseView();
-
-        List<CommentGroupDocument> groups = commentGroupRepository.findAllByPostId(postId); // 엔티티 직접
-
-        List<Long> groupIds = groups.stream()
-                .map(CommentGroupDocument::getId)
-                .toList();
-
-        List<CommentDocument> allComments = commentRepository.findAllByCommentGroupIdIn(groupIds); // 객체 리스트로 조회
-
-
-        List<PostGetResponse.CommentDto> comments = allComments.stream()
-                .filter(c -> c.getCommentOrder() == 1L)
-                .map(comment -> {
-                    List<PostGetResponse.ReCommentDto> reComments = allComments.stream()
-                            .filter(reply -> Objects.equals(reply.getCommentGroupId(), comment.getCommentGroupId())
-                                    && reply.getCommentOrder() > 1L)
-                            .map(reply -> new PostGetResponse.ReCommentDto(
-                                    reply.getId(),
-                                    getNickname(reply.getUserId()),
-                                    getProfileImage(reply.getUserId()),
-                                    reply.getContent()
-                            ))
-                            .toList();
-
-                    return new PostGetResponse.CommentDto(
-                            comment.getId(),
-                            getNickname(comment.getUserId()),
-                            getProfileImage(comment.getUserId()),
-                            comment.getContent(),
-                            reComments
-                    );
-                })
-                .toList();
-
-        return new PostGetResponse(
-                post.getId(),
-                post.getTag(),
-                post.getTitle(),
-                post.getTwpDate(),
-                getNickname(post.getWriterId()),
-                getProfileImage(post.getWriterId()),
-                post.getImageUrl(),
-                post.getDescription(),
-                comments
-        );
     }
 
     private String getNickname(Long userId) {

--- a/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
@@ -39,13 +39,21 @@ public interface PostControllerSpecification {
             summary = "커뮤니티 글 생성",
             description = "커뮤니티 글을 작성합니다.",
             security = @SecurityRequirement(name = "AccessCookie"),
-            parameters = @Parameter(
-                    name = "Access",
-                    description = "JWT access token (쿠키)",
-                    in = ParameterIn.COOKIE,
-                    required = true,
-                    example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-            ),
+            parameters = {
+                    @Parameter(
+                            name = "Access",
+                            description = "JWT access token (쿠키)",
+                            in = ParameterIn.COOKIE,
+                            required = true,
+                            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    ),
+                    @Parameter(
+                            name = "tag",
+                            in = ParameterIn.PATH,
+                            required = true,
+                            description = "해당 팀태그",
+                            example = "KIA_TIGERS"
+                    )},
             requestBody = @RequestBody(
                     required = true,
                     content = @Content(
@@ -129,7 +137,7 @@ public interface PostControllerSpecification {
                             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                     ),
                     @Parameter(
-                    name = "postId",
+                    name = "id",
                     in = ParameterIn.PATH,
                     required = true,
                     description = "삭제할 게시글 ID",
@@ -198,7 +206,7 @@ public interface PostControllerSpecification {
                             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                     ),
                     @Parameter(
-                    name = "postId",
+                    name = "id",
                     in = ParameterIn.PATH,
                     required = true,
                     description = "수정할 게시글 ID",
@@ -212,7 +220,6 @@ public interface PostControllerSpecification {
                                     name = "게시글 수정 요청 예시",
                                     value = """
                                     {
-                                      "postId": 1,
                                       "title": "오늘 경기 재밌었어요!",
                                       "image": "post.jpg",
                                       "content": "긴장하면서 시청했네요."
@@ -411,7 +418,7 @@ public interface PostControllerSpecification {
                             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                     ),
                     @Parameter(
-                            name = "postId",
+                            name = "id",
                             in = ParameterIn.PATH,
                             description = "게시물 ID",
                             required = true,
@@ -428,24 +435,22 @@ public interface PostControllerSpecification {
                                     name = "커뮤니티 글 조회 응답 예시",
                                     value = """
                                             {
+                                            	"tag" : "KEA_TIGERS",
                                             	"title":"오늘의 승리는 LG",
                                             	"date":"2025-03-20T00:00:00",
                                             	"writerNickname":"안타날릴",
                                             	"writerProfileImage":"profile.png",
-                                            	"activated":true,
                                             	"image":"image.png",
                                             	"content":"오늘은 LG가 이겨서 너무 행복합니다.",
                                             	"comments":[
                                             		{
                                             		"writerNickname":"난리나리라",
                                             		"writerProfileImage":"profiles.png",
-                                            		"activated":true,
                                             		"content":"홈런터질때 정말 짜릿했어요",
                                             		"reComments":[
                                             			{
                                             			"writerNickname":"테스형",
                                             			"writerProfileImage":"profile_11.png",
-                                            			"activated":true,
                                             			"content":"인정입니다."
                                             			}
                                             		]
@@ -521,6 +526,134 @@ public interface PostControllerSpecification {
                                             @PathVariable("postId") Long postId,
                                             JwtUser user);
 
+    @Tag(name = "Get", description = "ID 기반 커뮤니티 글 조회")
+    @Operation(
+            summary = "ID 기반 커뮤니티 글 조회 API",
+            description = "특정 게시물에 대한 자세한 정보를 ID를 기반으로 조회합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "Access",
+                            description = "JWT Access Token (쿠키)",
+                            in = ParameterIn.COOKIE,
+                            required = true,
+                            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    ),
+                    @Parameter(
+                            name = "id",
+                            in = ParameterIn.PATH,
+                            description = "게시물 ID",
+                            required = true,
+                            example = "1"
+                    ),
+                    @Parameter(
+                            name = "writerId",
+                            in = ParameterIn.PATH,
+                            description = "작성자 ID",
+                            required = true,
+                            example = "1"
+                    )
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "조회 성공",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "커뮤니티 글 조회 응답 예시",
+                                    value = """
+                                            {
+                                            	"tag" : "KEA_TIGERS",
+                                            	"title":"오늘의 승리는 LG",
+                                            	"date":"2025-03-20T00:00:00",
+                                            	"writerNickname":"안타날릴",
+                                            	"writerProfileImage":"profile.png",
+                                            	"image":"image.png",
+                                            	"content":"오늘은 LG가 이겨서 너무 행복합니다.",
+                                            	"comments":[
+                                            		{
+                                            		"writerNickname":"난리나리라",
+                                            		"writerProfileImage":"profiles.png",
+                                            		"content":"홈런터질때 정말 짜릿했어요",
+                                            		"reComments":[
+                                            			{
+                                            			"writerNickname":"테스형",
+                                            			"writerProfileImage":"profile_11.png",
+                                            			"content":"인정입니다."
+                                            			}
+                                            		]
+                                            		}
+                                            	]
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "게시물 ID가 1 미만일 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 400,
+                                              "status": "BAD_REQUEST",
+                                              "message": "게시물 ID는 1 이상이여야 합니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "인증 실패",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 401,
+                                              "status": "UNAUTHORIZED",
+                                              "message": "유효하지 않은 토큰입니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "게시물 ID로 게시물을 찾을 수 없는 경우 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 404,
+                                              "status": "NOT_FOUND",
+                                              "message": "게시물이 존재하지 않습니다!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 500,
+                                              "status": "INTERNAL_SERVER_ERROR",
+                                              "message": "서버 내부 오류가 발생했습니다. 관리자에게 문의해 주세요."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<PostGetResponse> getPostById(@PathVariable("writerId") Long writerId,
+                                                @PathVariable("postId") Long postId,
+                                                JwtUser user);
+
     @Tag(name = "Get", description = "커뮤니티 글 목록 조회 API")
     @Operation(
             summary = "팀별 커뮤니티 글 목록 조회",
@@ -534,11 +667,11 @@ public interface PostControllerSpecification {
                             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                     ),
                     @Parameter(
-                            name = "teamName",
+                            name = "tag",
                             description = "구단 이름",
                             in = ParameterIn.PATH,
                             required = true,
-                            example = "LG"
+                            example = "LG_TWINS"
                     )
             }
     )
@@ -552,14 +685,14 @@ public interface PostControllerSpecification {
                                     value = """
                                         [
                                             {
-                                                "postId": 1,
+                                                "id": 1,
                                                 "title": "오늘 경기 어땠나요?",
                                                 "writerNickname": "LG팬",
                                                 "createdDate": "2025-05-20",
                                                 "image": "LG.png"
                                             },
                                             {
-                                                "postId": 2,
+                                                "id": 2,
                                                 "title": "직관팟 모집",
                                                 "writerNickname": "야구사랑",
                                                 "createdDate": "2025-05-19",
@@ -650,7 +783,7 @@ public interface PostControllerSpecification {
                                     value = """
                                             [
                                                 {
-                                            	    "postId" : 1,
+                                            	    "id" : 1,
                                             	    "title" : "오늘은 직관은 아니지만..."
                                             	    "twpDate" : "2025-06-03",
                                             	    "nickname" : "KSH"

--- a/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
@@ -137,7 +137,7 @@ public interface PostControllerSpecification {
                             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                     ),
                     @Parameter(
-                    name = "id",
+                    name = "postId",
                     in = ParameterIn.PATH,
                     required = true,
                     description = "삭제할 게시글 ID",
@@ -206,7 +206,7 @@ public interface PostControllerSpecification {
                             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                     ),
                     @Parameter(
-                    name = "id",
+                    name = "postId",
                     in = ParameterIn.PATH,
                     required = true,
                     description = "수정할 게시글 ID",
@@ -418,7 +418,7 @@ public interface PostControllerSpecification {
                             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                     ),
                     @Parameter(
-                            name = "id",
+                            name = "postId",
                             in = ParameterIn.PATH,
                             description = "게시물 ID",
                             required = true,
@@ -539,7 +539,7 @@ public interface PostControllerSpecification {
                             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                     ),
                     @Parameter(
-                            name = "id",
+                            name = "postId",
                             in = ParameterIn.PATH,
                             description = "게시물 ID",
                             required = true,
@@ -667,7 +667,7 @@ public interface PostControllerSpecification {
                             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                     ),
                     @Parameter(
-                            name = "tag",
+                            name = "teamName",
                             description = "구단 이름",
                             in = ParameterIn.PATH,
                             required = true,
@@ -784,9 +784,9 @@ public interface PostControllerSpecification {
                                             [
                                                 {
                                             	    "id" : 1,
-                                            	    "title" : "오늘은 직관은 아니지만..."
+                                            	    "title" : "오늘은 직관은 아니지만...",
                                             	    "twpDate" : "2025-06-03",
-                                            	    "nickname" : "KSH"
+                                            	    "nickname" : "KSH",
                                             	    "image" : "KSH.png"
                                                 }
                                             ]

--- a/src/main/java/com/playus/communityservice/global/config/security/CorsConfig.java
+++ b/src/main/java/com/playus/communityservice/global/config/security/CorsConfig.java
@@ -34,8 +34,7 @@ public class CorsConfig {
         configuration.addAllowedMethod(HttpMethod.GET.name());
         configuration.addAllowedMethod(HttpMethod.POST.name());
         configuration.addAllowedMethod(HttpMethod.PUT.name());
-        configuration.addAllowedMethod(HttpMethod.DELETE.name());
-        configuration.addAllowedMethod(HttpMethod.OPTIONS.name());
+        configuration.addAllowedMethod(HttpMethod.PATCH.name());
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
```
@GetMapping("/writer/{writerId}/{postId}")
    public ResponseEntity<PostGetResponse> getPostById(@PathVariable Long writerId,
                                                       @PathVariable Long postId,
                                                       @AuthenticationPrincipal JwtUser user) {
        PostGetResponse response = postReadOnlyService.getPostById(writerId, postId, user);
        return ResponseEntity.ok(response);
    }
```
위와 같은 형식으로 API 구현

```
if (!post.getWriterId().equals(writerId)) {
            throw new EntityNotFoundException("작성자와 게시글이 일치하지 않습니다.");
        }
```
Service에 getPostById를 만들어 기존 getPost와 구분하였습니다

---

## 🔗 관련 이슈
- closes #66 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 작성자 ID와 게시글 ID로 단일 게시글을 조회할 수 있는 새로운 엔드포인트가 추가되었습니다.

- **기능 개선**
  - 게시글 상세 응답에 팀 태그 정보가 추가되었습니다.
  - 댓글 및 대댓글에서 'activated' 필드가 제거되었습니다.
  - API 문서의 파라미터 명칭과 예시가 일관성 있게 정비되었습니다.
  - 댓글 삭제 및 수정 API에서 댓글 ID가 경로 파라미터로 변경되었습니다.
  - CORS 설정에서 PATCH 메서드가 허용되고 DELETE, OPTIONS 메서드는 제외되었습니다.

- **문서화**
  - Swagger/OpenAPI 문서가 개선되어, 파라미터 설명과 예시, 응답 예시가 더 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->