### PR TITLE
Cs 426 refactor/댓글 관련 코드 수정

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/comment/repository/write/CommentRepository.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/repository/write/CommentRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByCommentGroup(CommentGroup commentGroup);
+    boolean existsByCommentGroupAndIsActivatedTrue(CommentGroup commentGroup);
 }

--- a/src/main/java/com/playus/communityservice/domain/comment/service/CommentService.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/service/CommentService.java
@@ -45,10 +45,14 @@ public class CommentService {
             commentGroupRepository.save(commentGroup);
             order = 1;
         } else {
-            Comment parent = commentRepository.findById(request.commentGroupId())
-                    .orElseThrow(() -> new EntityNotFoundException("부모 댓글"));
             commentGroup = commentGroupRepository.findById(request.commentGroupId())
                     .orElseThrow(() -> new EntityNotFoundException("댓글 그룹"));
+
+            boolean hasActiveComments = commentRepository.existsByCommentGroupAndIsActivatedTrue(commentGroup);
+            if (!hasActiveComments) {
+                throw new IllegalArgumentException("삭제된 댓글 그룹에는 답글을 작성할 수 없습니다.");
+            }
+
             order = 2;
         }
 

--- a/src/main/java/com/playus/communityservice/domain/comment/service/CommentService.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/service/CommentService.java
@@ -47,10 +47,8 @@ public class CommentService {
         } else {
             Comment parent = commentRepository.findById(request.commentGroupId())
                     .orElseThrow(() -> new EntityNotFoundException("부모 댓글"));
-            if (parent.getCommentOrder() != 1L) {
-                throw new IllegalArgumentException("부모 댓글에만 답글을 작성할 수 있습니다.");
-            }
-            commentGroup = parent.getCommentGroup();
+            commentGroup = commentGroupRepository.findById(request.commentGroupId())
+                    .orElseThrow(() -> new EntityNotFoundException("댓글 그룹"));
             order = 2;
         }
 

--- a/src/main/java/com/playus/communityservice/domain/comment/specification/CommentControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/specification/CommentControllerSpecification.java
@@ -79,7 +79,7 @@ public interface CommentControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 400,
-                                                "statue" : "BAD_REQUEST"
+                                                "statue" : "BAD_REQUEST",
                                                 "message" : "댓글의 내용을 1~100자 이내로 작성해 주세요!"
                                             }
                                             """
@@ -116,6 +116,7 @@ public interface CommentControllerSpecification {
                                     name = "커뮤니티 댓글 삭제 요청 예시",
                                     value = """
                                             {
+                                                "commentId":3,
                                                 "commentGroupId" : 2
                                             }
                                             """
@@ -147,7 +148,7 @@ public interface CommentControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 404,
-                                                "statue" : "NOT_FOUND"
+                                                "statue" : "NOT_FOUND",
                                                 "message" : "해당 댓글을 찾을 수 없습니다."
                                             }
                                             """
@@ -162,7 +163,7 @@ public interface CommentControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 403,
-                                                "statue" : "FORBIDDEN"
+                                                "statue" : "FORBIDDEN",
                                                 "message" : "해당 댓글에 대한 권한이 없습니다."
                                             }
                                             """
@@ -201,6 +202,7 @@ public interface CommentControllerSpecification {
                                     name = "댓글/답글 수정 요청 예시",
                                     value = """
                                             {
+                                                "commentId":3,
                                                 "commentGroupId" : 2,
                                                 "content" : "아슬아슬하게 이겼네요!"
                                             }
@@ -233,7 +235,7 @@ public interface CommentControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 404,
-                                                "statue" : "NOT_FOUND"
+                                                "statue" : "NOT_FOUND",
                                                 "message" : "해당 댓글을 찾을 수 없습니다."
                                             }
                                             """
@@ -248,7 +250,7 @@ public interface CommentControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 403,
-                                                "statue" : "FORBIDDEN"
+                                                "statue" : "FORBIDDEN",
                                                 "message" : "해당 댓글에 대한 권한이 없습니다."
                                             }
                                             """
@@ -263,7 +265,7 @@ public interface CommentControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 400,
-                                                "statue" : "BAD_REQUEST"
+                                                "statue" : "BAD_REQUEST",
                                                 "message" : "댓글의 내용을 1~100자 이내로 작성해 주세요!"
                                             }
                                             """

--- a/src/main/java/com/playus/communityservice/domain/post/dto/post_view/PostGetResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/post/dto/post_view/PostGetResponse.java
@@ -20,6 +20,7 @@ public record PostGetResponse(
 ) {
     public record CommentDto(
             Long commentId,
+            Long commentGroupId,
             String writerNickname,
             String writerProfileImage,
             String content,
@@ -28,6 +29,7 @@ public record PostGetResponse(
 
     public record ReCommentDto(
             Long reCommentId,
+            Long commentGroupId,
             String writerNickname,
             String writerProfileImage,
             String content

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -60,13 +60,15 @@ public class PostReadOnlyService {
         List<CommentDocument> allComments = commentRepository.findAllByCommentGroupIdIn(groupIds);
 
         List<PostGetResponse.CommentDto> comments = allComments.stream()
-                .filter(c -> c.getCommentOrder() == 1L)
+                .filter(c -> c.getCommentOrder() == 1L && c.isActivated())
                 .map(comment -> {
                     List<PostGetResponse.ReCommentDto> reComments = allComments.stream()
                             .filter(reply -> Objects.equals(reply.getCommentGroupId(), comment.getCommentGroupId())
-                                    && reply.getCommentOrder() > 1L)
+                                    && reply.getCommentOrder() > 1L
+                                    && reply.isActivated())
                             .map(reply -> new PostGetResponse.ReCommentDto(
                                     reply.getId(),
+                                    reply.getCommentGroupId(),
                                     getNickname(reply.getUserId()),
                                     getProfileImage(reply.getUserId()),
                                     reply.getContent()
@@ -75,6 +77,7 @@ public class PostReadOnlyService {
 
                     return new PostGetResponse.CommentDto(
                             comment.getId(),
+                            comment.getCommentGroupId(),
                             getNickname(comment.getUserId()),
                             getProfileImage(comment.getUserId()),
                             comment.getContent(),

--- a/src/main/java/com/playus/communityservice/domain/post/specification/LiveMatchDiaryControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/LiveMatchDiaryControllerSpecification.java
@@ -85,7 +85,7 @@ public interface LiveMatchDiaryControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 400,
-                                                "statue" : "BAD_REQUEST"
+                                                "statue" : "BAD_REQUEST",
                                                 "message" : "직관일지의 제목이 비어있습니다!"
                                             }
                                             """
@@ -100,7 +100,7 @@ public interface LiveMatchDiaryControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 400,
-                                                "statue" : "BAD_REQUEST"
+                                                "statue" : "BAD_REQUEST",
                                                 "message" : "직관일지의 내용을 1~500자 이내로 작성해 주세요!"
                                             }
                                             """
@@ -156,7 +156,7 @@ public interface LiveMatchDiaryControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 404,
-                                                "statue" : "NOT_FOUND"
+                                                "statue" : "NOT_FOUND",
                                                 "message" : "해당 직관일지를 찾을 수 없습니다."
                                             }
                                             """
@@ -229,7 +229,7 @@ public interface LiveMatchDiaryControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 404,
-                                                "statue" : "NOT_FOUND"
+                                                "statue" : "NOT_FOUND",
                                                 "message" : "해당 직관일지를 찾을 수 없습니다."
                                             }
                                             """
@@ -244,7 +244,7 @@ public interface LiveMatchDiaryControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 400,
-                                                "statue" : "BAD_REQUEST"
+                                                "statue" : "BAD_REQUEST",
                                                 "message" : "직관일지의 제목이 비어있습니다!"
                                             }
                                             """
@@ -259,7 +259,7 @@ public interface LiveMatchDiaryControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 400,
-                                                "statue" : "BAD_REQUEST"
+                                                "statue" : "BAD_REQUEST",
                                                 "message" : "직관일지의 내용을 1~500자 이내로 작성해 주세요!"
                                             }
                                             """

--- a/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
@@ -97,7 +97,7 @@ public interface PostControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 400,
-                                                "statue" : "BAD_REQUEST"
+                                                "statue" : "BAD_REQUEST",
                                                 "message" : "게시글의 제목이 비어있습니다!"
                                             }
                                             """
@@ -112,7 +112,7 @@ public interface PostControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 400,
-                                                "statue" : "BAD_REQUEST"
+                                                "statue" : "BAD_REQUEST",
                                                 "message" : "게시글의 내용을 1~500자 이내로 작성해 주세요!"
                                             }
                                             """
@@ -168,7 +168,7 @@ public interface PostControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 404,
-                                                "statue" : "NOT_FOUND"
+                                                "statue" : "NOT_FOUND",
                                                 "message" : "해당 게시글을 찾을 수 없습니다."
                                             }
                                             """
@@ -183,7 +183,7 @@ public interface PostControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 403,
-                                                "statue" : "FORBIDDEN"
+                                                "statue" : "FORBIDDEN",
                                                 "message" : "해당 게시글에 대한 권한이 없습니다."
                                             }
                                             """
@@ -220,9 +220,10 @@ public interface PostControllerSpecification {
                                     name = "게시글 수정 요청 예시",
                                     value = """
                                     {
+                                      "postId":1,
                                       "title": "오늘 경기 재밌었어요!",
                                       "image": "post.jpg",
-                                      "content": "긴장하면서 시청했네요."
+                                      "content": "긴장하면서 시청했네요.",
                                       "twpDate" : "2025-05-01",
                                       "isSecret": false
                                     }
@@ -255,7 +256,7 @@ public interface PostControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 404,
-                                                "statue" : "NOT_FOUND"
+                                                "statue" : "NOT_FOUND",
                                                 "message" : "해당 게시글을 찾을 수 없습니다."
                                             }
                                             """
@@ -270,7 +271,7 @@ public interface PostControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 403,
-                                                "statue" : "FORBIDDEN"
+                                                "statue" : "FORBIDDEN",
                                                 "message" : "해당 게시글에 대한 권한이 없습니다."
                                             }
                                             """
@@ -285,7 +286,7 @@ public interface PostControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 400,
-                                                "statue" : "BAD_REQUEST"
+                                                "statue" : "BAD_REQUEST",
                                                 "message" : "게시글의 제목이 비어있습니다!"
                                             }
                                             """
@@ -300,7 +301,7 @@ public interface PostControllerSpecification {
                                     value = """
                                             {
                                                 "code" : 400,
-                                                "statue" : "BAD_REQUEST"
+                                                "statue" : "BAD_REQUEST",
                                                 "message" : "게시글의 내용을 1~500자 이내로 작성해 주세요!"
                                             }
                                             """
@@ -444,11 +445,13 @@ public interface PostControllerSpecification {
                                             	"content":"오늘은 LG가 이겨서 너무 행복합니다.",
                                             	"comments":[
                                             		{
+                                            		"commentGroupId": 1,
                                             		"writerNickname":"난리나리라",
                                             		"writerProfileImage":"profiles.png",
                                             		"content":"홈런터질때 정말 짜릿했어요",
                                             		"reComments":[
                                             			{
+                                            			"commentGroupId": 1,
                                             			"writerNickname":"테스형",
                                             			"writerProfileImage":"profile_11.png",
                                             			"content":"인정입니다."
@@ -572,11 +575,13 @@ public interface PostControllerSpecification {
                                             	"content":"오늘은 LG가 이겨서 너무 행복합니다.",
                                             	"comments":[
                                             		{
+                                            		"commentGroupId": 1,
                                             		"writerNickname":"난리나리라",
                                             		"writerProfileImage":"profiles.png",
                                             		"content":"홈런터질때 정말 짜릿했어요",
                                             		"reComments":[
                                             			{
+                                            			"commentGroupId": 1,
                                             			"writerNickname":"테스형",
                                             			"writerProfileImage":"profile_11.png",
                                             			"content":"인정입니다."


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
```
commentGroup = commentGroupRepository.findById(request.commentGroupId())
                    .orElseThrow(() -> new EntityNotFoundException("댓글 그룹"));
```
대댓글을 생성할 때, commentGroupId가 정확히 매핑되도록 수정

```
return new PostGetResponse.CommentDto(
                            comment.getId(),
                            comment.getCommentGroupId(),
                            getNickname(comment.getUserId()),
                            getProfileImage(comment.getUserId()),
                            comment.getContent(),
                            reComments
                    );
```
response에 commentGroupId도 보이도록 수정

```
.filter(c -> c.getCommentOrder() == 1L && c.isActivated())
```
```
.filter(reply -> Objects.equals(reply.getCommentGroupId(), comment.getCommentGroupId())
                                    && reply.getCommentOrder() > 1L
                                    && reply.isActivated())
```
에 isActivated()를 추가하여 삭제된 댓글은 조회되지 않도록 하였습니다.

---

## 🔗 관련 이슈
- closes #68 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 댓글 및 대댓글 데이터에 commentGroupId 필드가 추가되어, 각 댓글이 속한 그룹 정보를 확인할 수 있습니다.

- **버그 수정**
    - API 문서(Swagger) 내 예시 JSON의 형식 오류가 수정되어, 잘못된 쉼표 누락 등이 보완되었습니다.

- **기타**
    - 비활성화된 댓글 및 답글이 게시글 상세 조회 시 더 이상 노출되지 않습니다.
    - API 문서 예시에 commentGroupId, commentId, postId 등 추가 정보가 포함되어 예시가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->