### PR TITLE
Refactor: comment dto 수정

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/comment/dto/comment_create/CommentCreateResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/dto/comment_create/CommentCreateResponse.java
@@ -5,15 +5,19 @@ import lombok.Builder;
 @Builder
 public record CommentCreateResponse(
         Long commentId,
+        Long userId,
         String message,
-        Long commentGroupId
+        Long commentGroupId,
+        String content
 ) {
 
-    public static CommentCreateResponse of(Long commentId, Long commentGroupId, String message) {
+    public static CommentCreateResponse of(Long userId,Long commentId, Long commentGroupId, String message, String content) {
         return CommentCreateResponse.builder()
+                .userId(userId)
                 .commentId(commentId)
                 .commentGroupId(commentGroupId)
                 .message(message)
+                .content(content)
                 .build();
     }
 }

--- a/src/main/java/com/playus/communityservice/domain/comment/dto/comment_update/CommentUpdateResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/dto/comment_update/CommentUpdateResponse.java
@@ -5,13 +5,17 @@ import lombok.Builder;
 @Builder
 public record CommentUpdateResponse(
         boolean success,
-        String message
+        String message,
+        Long userId,
+        String content
 ) {
 
-    public static CommentUpdateResponse of(boolean success, String message) {
+    public static CommentUpdateResponse of(boolean success, String message, Long userId, String content) {
         return CommentUpdateResponse.builder()
                 .success(success)
                 .message(message)
+                .userId(userId)
+                .content(content)
                 .build();
     }
 }

--- a/src/main/java/com/playus/communityservice/domain/comment/service/CommentService.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/service/CommentService.java
@@ -82,7 +82,12 @@ public class CommentService {
             log.warn("댓글 알림 전송 실패: commentId={}, error={}", comment.getId(), e.getMessage());
         }
 
-        return CommentCreateResponse.of(comment.getId(),comment.getCommentGroup().getId(), "댓글 생성이 완료되었습니다.");
+        return CommentCreateResponse.of(
+                user.getId(),
+                comment.getId(),
+                comment.getCommentGroup().getId(),
+                "댓글 생성이 완료되었습니다.",
+                comment.getContent());
     }
 
     public CommentUpdateResponse updateComment(CommentUpdateRequest request, JwtUser user) {
@@ -98,7 +103,7 @@ public class CommentService {
         }
 
         comment.updateContent(request.content());
-        return CommentUpdateResponse.of(true,"댓글이 수정되었습니다.");
+        return CommentUpdateResponse.of(true,"댓글이 수정되었습니다.",user.getId(),comment.getContent());
     }
 
     public CommentDeleteResponse deleteComment(CommentDeleteRequest request, JwtUser user) {

--- a/src/main/java/com/playus/communityservice/domain/comment/specification/CommentControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/specification/CommentControllerSpecification.java
@@ -63,9 +63,11 @@ public interface CommentControllerSpecification {
                                     name = "커뮤니티 댓글 생성 응답 예시",
                                     value = """
                                             {
+                                                "userId": 3,
                                                 "commentId" : 3,
                                                 "commentGroupId" : 2,
-                                                "message" : "댓글 작성이 완료되었습니다."
+                                                "message" : "댓글 작성이 완료되었습니다.",
+                                                "content": "직관가신거 너무 부러워요."
                                             }
                                             """
                             )
@@ -221,7 +223,9 @@ public interface CommentControllerSpecification {
                                     value = """
                                             {
                                                 "success" : true,
-                                                "message" : "댓글이 수정되었습니다."
+                                                "message" : "댓글이 수정되었습니다.",
+                                                "userId" : 2,
+                                                "content" : "가을 야구 가보자구~"
                                             }
                                             """
                             )

--- a/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
+++ b/src/main/java/com/playus/communityservice/domain/post/specification/PostControllerSpecification.java
@@ -788,7 +788,7 @@ public interface PostControllerSpecification {
                                     value = """
                                             [
                                                 {
-                                            	    "id" : 1,
+                                            	    "postId" : 1,
                                             	    "title" : "오늘은 직관은 아니지만...",
                                             	    "twpDate" : "2025-06-03",
                                             	    "nickname" : "KSH",
@@ -800,7 +800,7 @@ public interface PostControllerSpecification {
                     )
             ),
             @ApiResponse(
-                    responseCode = "400", description = "writerID가 1 미만일 경우 발생",
+                    responseCode = "400", description = "postID가 1 미만일 경우 발생",
                     content = @Content(
                             mediaType = APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(
@@ -808,7 +808,7 @@ public interface PostControllerSpecification {
                                             {
                                               "code": 400,
                                               "status": "BAD_REQUEST",
-                                              "message": "writerID는 1 이상이여야 합니다!"
+                                              "message": "postID는 1 이상이여야 합니다!"
                                             }
                                             """
                             )


### PR DESCRIPTION
- CommentCreateResponse에 userId와 content 추가
- CommentUpdateResponse에 userId와 content 추가

## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
프론트의 요청으로 `CommentCreateResponse`와 `CommentUpdateResponse`에 `userId`와 `content`를 추가하였습니다.

---

## 🔗 관련 이슈
- closes #73 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 댓글 생성 및 수정 시 응답에 userId와 content(댓글 내용) 정보가 추가되어, 댓글 작성자와 내용을 확인할 수 있습니다.

- **문서화**
	- 댓글 생성 및 수정 API의 응답 예시에 userId와 content 필드가 반영되었습니다.
	- 게시글 조회 API의 예시 및 오류 메시지에서 "writerId"를 "postId"로 일관성 있게 변경하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->