### PR TITLE
Feat: user쪽에서 회원의 닉네임과 프로필 이미지 받아오기

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -11,6 +11,7 @@ import com.playus.communityservice.domain.post.dto.post_view.PostGetResponse;
 import com.playus.communityservice.domain.post.dto.post_view.PostListResponse;
 import com.playus.communityservice.domain.post.enums.TeamTag;
 import com.playus.communityservice.domain.post.repository.read.PostReadOnlyRepository;
+import com.playus.communityservice.domain.post.userInfo.UserInfoResponse;
 import com.playus.communityservice.domain.post.userInfo.UserReadService;
 import com.playus.communityservice.global.exception.EntityNotFoundException;
 import com.playus.communityservice.domain.common.security.JwtUser;
@@ -31,6 +32,7 @@ public class PostReadOnlyService {
     private final CommentReadOnlyRepository commentRepository;
     private final CommentGroupReadOnlyRepository commentGroupRepository;
     private final UserReadService userReadService;
+    private record UserInfo(String nickname, String profileImage) {}
 
     public PostGetResponse getPost(Long postId, JwtUser user) {
         return buildPostGetResponse(postId, null);
@@ -170,12 +172,27 @@ public class PostReadOnlyService {
                 .toList();
     }
 
+    private UserInfo getUserInfo(Long userId) {
+        try {
+            UserInfoResponse user = userReadService.getUserInfo(userId);
+            if (user == null) return new UserInfo("알 수 없음", "");
+            return new UserInfo(
+                    user.getNickname() != null ? user.getNickname() : "알 수 없음",
+                    user.getThumbnailUrl() != null ? user.getThumbnailUrl() : ""
+            );
+        } catch (Exception e) {
+            return new UserInfo("알 수 없음", "");
+        }
+    }
+
+
     private String getNickname(Long userId) {
-        return userReadService.getUserInfo(userId).getNickname();
+        return getUserInfo(userId).nickname();
     }
 
     private String getProfileImage(Long userId) {
-        return userReadService.getUserInfo(userId).getThumbnailUrl();
+        return getUserInfo(userId).profileImage();
     }
+
 
 }

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -11,6 +11,7 @@ import com.playus.communityservice.domain.post.dto.post_view.PostGetResponse;
 import com.playus.communityservice.domain.post.dto.post_view.PostListResponse;
 import com.playus.communityservice.domain.post.enums.TeamTag;
 import com.playus.communityservice.domain.post.repository.read.PostReadOnlyRepository;
+import com.playus.communityservice.domain.post.userInfo.UserReadService;
 import com.playus.communityservice.global.exception.EntityNotFoundException;
 import com.playus.communityservice.domain.common.security.JwtUser;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +30,7 @@ public class PostReadOnlyService {
     private final PostReadOnlyRepository postRepository;
     private final CommentReadOnlyRepository commentRepository;
     private final CommentGroupReadOnlyRepository commentGroupRepository;
+    private final UserReadService userReadService;
 
     public PostGetResponse getPost(Long postId, JwtUser user) {
         return buildPostGetResponse(postId, null);
@@ -169,14 +171,11 @@ public class PostReadOnlyService {
     }
 
     private String getNickname(Long userId) {
-        return "User#" + userId; // TODO: 유저 서비스 연동
+        return userReadService.getUserInfo(userId).getNickname();
     }
 
     private String getProfileImage(Long userId) {
-        return "https://example.com/profile/" + userId + ".png"; // TODO: 유저 서비스 연동
+        return userReadService.getUserInfo(userId).getThumbnailUrl();
     }
 
-    private boolean isExpert(Long userId) {
-        return false; // TODO: 유저 서비스 연동
-    }
 }

--- a/src/main/java/com/playus/communityservice/domain/post/userInfo/PartyApplicantsInfoFeignResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/post/userInfo/PartyApplicantsInfoFeignResponse.java
@@ -1,0 +1,22 @@
+package com.playus.communityservice.domain.post.userInfo;
+
+import lombok.Builder;
+
+@Builder
+public record PartyApplicantsInfoFeignResponse(
+        Long userId,
+        String name,
+        int age,
+        String thumbnailUrl
+) {
+
+    public static PartyApplicantsInfoFeignResponse of(Long userId, String name, int age, String thumbnailUrl) {
+        return PartyApplicantsInfoFeignResponse.builder()
+                .userId(userId)
+                .name(name)
+                .age(age)
+                .thumbnailUrl(thumbnailUrl)
+                .build();
+    }
+
+}

--- a/src/main/java/com/playus/communityservice/domain/post/userInfo/UserInfoResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/post/userInfo/UserInfoResponse.java
@@ -1,0 +1,15 @@
+package com.playus.communityservice.domain.post.userInfo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserInfoResponse {
+    private Long id;
+    private String nickname;
+    private String thumbnailUrl;
+}
+

--- a/src/main/java/com/playus/communityservice/domain/post/userInfo/UserQueryClient.java
+++ b/src/main/java/com/playus/communityservice/domain/post/userInfo/UserQueryClient.java
@@ -1,0 +1,19 @@
+package com.playus.communityservice.domain.post.userInfo;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@FeignClient(
+        name = "userQueryClient",
+        url = "${feign.user.url}",
+        path = "/user/api"
+)
+public interface UserQueryClient {
+
+    @PostMapping("/info")
+    List<PartyApplicantsInfoFeignResponse> getUserInfos(@RequestBody List<Long> userIdList);
+}
+

--- a/src/main/java/com/playus/communityservice/domain/post/userInfo/UserReadService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/userInfo/UserReadService.java
@@ -1,0 +1,27 @@
+package com.playus.communityservice.domain.post.userInfo;
+
+import com.playus.communityservice.global.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserReadService {
+
+    private final UserQueryClient userQueryClient;
+
+    public UserInfoResponse getUserInfo(Long userId) {
+        List<PartyApplicantsInfoFeignResponse> users = userQueryClient.getUserInfos(List.of(userId));
+
+        if (users.isEmpty()) {
+            throw new EntityNotFoundException("사용자");
+        }
+
+        PartyApplicantsInfoFeignResponse info = users.get(0);
+
+        return new UserInfoResponse(info.userId(), info.name(), info.thumbnailUrl());
+    }
+}
+

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -55,7 +55,7 @@ server:
 
 feign:
   user:
-    url: http://user-service:8080
+    url: http://localhost:8080
 
 management:
   endpoints:


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
![image](https://github.com/user-attachments/assets/a8d18d3a-cfc4-4584-a3a0-a7e4f7079ab0)
user쪽에서 닉네임과 프로필 이미지를 받아 오는 로직을 구현

```
private String getNickname(Long userId) {
        return userReadService.getUserInfo(userId).getNickname();
    }

    private String getProfileImage(Long userId) {
        return userReadService.getUserInfo(userId).getThumbnailUrl();
    }
```
로 구현을 완료

---

## 🔗 관련 이슈
- closes #78 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 외부 사용자 서비스와 연동하여 게시글에 사용자 정보(닉네임, 프로필 이미지 등)를 표시하도록 개선되었습니다.
    - 사용자 정보를 조회하는 기능이 추가되었습니다.
    - 사용자 정보 조회를 위한 새로운 데이터 구조와 클라이언트 인터페이스가 도입되었습니다.

- **버그 수정**
    - 기존에 임시값으로 표시되던 사용자 정보가 실제 데이터로 대체되었습니다.

- **환경 설정**
    - 로컬 환경에서 사용자 서비스 연동을 위한 접속 주소가 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->