### PR TITLE
Cs 438 fix/유저 프로필 이미지가 null로 뜨는 오류 해결

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/comment/service/CommentService.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/service/CommentService.java
@@ -12,6 +12,8 @@ import com.playus.communityservice.domain.comment.repository.write.CommentGroupR
 import com.playus.communityservice.domain.comment.repository.write.CommentRepository;
 import com.playus.communityservice.domain.post.entity.Post;
 import com.playus.communityservice.domain.post.repository.write.PostRepository;
+import com.playus.communityservice.domain.common.userInfo.UserInfo;
+import com.playus.communityservice.domain.common.userInfo.UserReadService;
 import com.playus.communityservice.global.client.CommentNotificationEvent;
 import com.playus.communityservice.global.client.UserNotificationClient;
 import com.playus.communityservice.domain.common.security.JwtUser;
@@ -32,6 +34,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final CommentGroupRepository commentGroupRepository;
     private final UserNotificationClient userNotificationClient;
+    private final UserReadService userReadService; // ✅ 추가
 
     public CommentCreateResponse createComment(CommentCreateRequest request, JwtUser user) {
         Post post = postRepository.findById(request.postId())
@@ -69,6 +72,7 @@ public class CommentService {
 
         commentRepository.save(comment);
 
+        // 알림 전송
         CommentNotificationEvent event = CommentNotificationEvent.of(
                 comment.getId(),
                 post.getId(),
@@ -82,14 +86,18 @@ public class CommentService {
             log.warn("댓글 알림 전송 실패: commentId={}, error={}", comment.getId(), e.getMessage());
         }
 
+        // ✅ 작성자 정보 가져오기
+        UserInfo userInfo = UserInfo.from(userReadService, user.getId());
+
         return CommentCreateResponse.of(
                 user.getId(),
                 comment.getId(),
                 comment.getCommentGroup().getId(),
                 "댓글 생성이 완료되었습니다.",
                 comment.getContent(),
-                user.getNickname(),
-                user.getThumbnailURL());
+                userInfo.nickname(),
+                userInfo.profileImage()
+        );
     }
 
     public CommentUpdateResponse updateComment(CommentUpdateRequest request, JwtUser user) {
@@ -105,13 +113,18 @@ public class CommentService {
         }
 
         comment.updateContent(request.content());
+
+        // ✅ 작성자 정보 가져오기
+        UserInfo userInfo = UserInfo.from(userReadService, user.getId());
+
         return CommentUpdateResponse.of(
                 true,
                 "댓글이 수정되었습니다.",
                 user.getId(),
                 comment.getContent(),
-                user.getNickname(),
-                user.getThumbnailURL());
+                userInfo.nickname(),
+                userInfo.profileImage()
+        );
     }
 
     public CommentDeleteResponse deleteComment(CommentDeleteRequest request, JwtUser user) {

--- a/src/main/java/com/playus/communityservice/domain/common/userInfo/PartyApplicantsInfoFeignResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/common/userInfo/PartyApplicantsInfoFeignResponse.java
@@ -1,4 +1,4 @@
-package com.playus.communityservice.domain.post.userInfo;
+package com.playus.communityservice.domain.common.userInfo;
 
 import lombok.Builder;
 

--- a/src/main/java/com/playus/communityservice/domain/common/userInfo/UserInfo.java
+++ b/src/main/java/com/playus/communityservice/domain/common/userInfo/UserInfo.java
@@ -1,0 +1,20 @@
+package com.playus.communityservice.domain.common.userInfo;
+
+public record UserInfo(
+        String nickname,
+        String profileImage
+) {
+    public static UserInfo from(UserReadService userReadService, Long userId) {
+        try {
+            UserInfoResponse user = userReadService.getUserInfo(userId);
+            if (user == null) return new UserInfo("알 수 없음", "");
+
+            return new UserInfo(
+                    user.getNickname() != null ? user.getNickname() : "알 수 없음",
+                    user.getThumbnailUrl() != null ? user.getThumbnailUrl() : ""
+            );
+        } catch (Exception e) {
+            return new UserInfo("알 수 없음", "");
+        }
+    }
+}

--- a/src/main/java/com/playus/communityservice/domain/common/userInfo/UserInfoResponse.java
+++ b/src/main/java/com/playus/communityservice/domain/common/userInfo/UserInfoResponse.java
@@ -1,4 +1,4 @@
-package com.playus.communityservice.domain.post.userInfo;
+package com.playus.communityservice.domain.common.userInfo;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/playus/communityservice/domain/common/userInfo/UserQueryClient.java
+++ b/src/main/java/com/playus/communityservice/domain/common/userInfo/UserQueryClient.java
@@ -1,4 +1,4 @@
-package com.playus.communityservice.domain.post.userInfo;
+package com.playus.communityservice.domain.common.userInfo;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/playus/communityservice/domain/common/userInfo/UserReadService.java
+++ b/src/main/java/com/playus/communityservice/domain/common/userInfo/UserReadService.java
@@ -1,4 +1,4 @@
-package com.playus.communityservice.domain.post.userInfo;
+package com.playus.communityservice.domain.common.userInfo;
 
 import com.playus.communityservice.global.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -11,8 +11,8 @@ import com.playus.communityservice.domain.post.dto.post_view.PostGetResponse;
 import com.playus.communityservice.domain.post.dto.post_view.PostListResponse;
 import com.playus.communityservice.domain.post.enums.TeamTag;
 import com.playus.communityservice.domain.post.repository.read.PostReadOnlyRepository;
-import com.playus.communityservice.domain.post.userInfo.UserInfoResponse;
-import com.playus.communityservice.domain.post.userInfo.UserReadService;
+import com.playus.communityservice.domain.common.userInfo.UserInfo;
+import com.playus.communityservice.domain.common.userInfo.UserReadService;
 import com.playus.communityservice.global.exception.EntityNotFoundException;
 import com.playus.communityservice.domain.common.security.JwtUser;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,7 +32,6 @@ public class PostReadOnlyService {
     private final CommentReadOnlyRepository commentRepository;
     private final CommentGroupReadOnlyRepository commentGroupRepository;
     private final UserReadService userReadService;
-    private record UserInfo(String nickname, String profileImage) {}
 
     public PostGetResponse getPost(Long postId, JwtUser user) {
         return buildPostGetResponse(postId, null);
@@ -55,6 +54,7 @@ public class PostReadOnlyService {
         }
 
         post.increaseView();
+        postRepository.save(post);
 
         List<CommentGroupDocument> groups = commentGroupRepository.findAllByPostId(postId);
         List<Long> groupIds = groups.stream()
@@ -66,37 +66,44 @@ public class PostReadOnlyService {
         List<PostGetResponse.CommentDto> comments = allComments.stream()
                 .filter(c -> c.getCommentOrder() == 1L && c.isActivated())
                 .map(comment -> {
+                    UserInfo userInfo = UserInfo.from(userReadService, comment.getUserId());
+
                     List<PostGetResponse.ReCommentDto> reComments = allComments.stream()
                             .filter(reply -> Objects.equals(reply.getCommentGroupId(), comment.getCommentGroupId())
                                     && reply.getCommentOrder() > 1L
                                     && reply.isActivated())
-                            .map(reply -> new PostGetResponse.ReCommentDto(
-                                    reply.getId(),
-                                    reply.getCommentGroupId(),
-                                    getNickname(reply.getUserId()),
-                                    getProfileImage(reply.getUserId()),
-                                    reply.getContent()
-                            ))
+                            .map(reply -> {
+                                UserInfo replyUser = UserInfo.from(userReadService, reply.getUserId());
+                                return new PostGetResponse.ReCommentDto(
+                                        reply.getId(),
+                                        reply.getCommentGroupId(),
+                                        replyUser.nickname(),
+                                        replyUser.profileImage(),
+                                        reply.getContent()
+                                );
+                            })
                             .toList();
 
                     return new PostGetResponse.CommentDto(
                             comment.getId(),
                             comment.getCommentGroupId(),
-                            getNickname(comment.getUserId()),
-                            getProfileImage(comment.getUserId()),
+                            userInfo.nickname(),
+                            userInfo.profileImage(),
                             comment.getContent(),
                             reComments
                     );
                 })
                 .toList();
 
+        UserInfo writerInfo = UserInfo.from(userReadService, post.getWriterId());
+
         return new PostGetResponse(
                 post.getId(),
                 post.getTag(),
                 post.getTitle(),
                 post.getTwpDate(),
-                getNickname(post.getWriterId()),
-                getProfileImage(post.getWriterId()),
+                writerInfo.nickname(),
+                writerInfo.profileImage(),
                 post.getImageUrl(),
                 post.getDescription(),
                 comments
@@ -127,13 +134,16 @@ public class PostReadOnlyService {
 
         return posts.stream()
                 .filter(PostDocument::isActivated)
-                .map(post -> new PostListResponse(
-                        post.getId(),
-                        post.getTitle(),
-                        post.getCreatedAt().toLocalDate(),
-                        getNickname(post.getWriterId()),
-                        post.getImageUrl()
-                ))
+                .map(post -> {
+                    UserInfo writerInfo = UserInfo.from(userReadService, post.getWriterId());
+                    return new PostListResponse(
+                            post.getId(),
+                            post.getTitle(),
+                            post.getCreatedAt().toLocalDate(),
+                            writerInfo.nickname(),
+                            post.getImageUrl()
+                    );
+                })
                 .toList();
     }
 
@@ -162,37 +172,17 @@ public class PostReadOnlyService {
 
         return posts.stream()
                 .filter(PostDocument::isActivated)
-                .map(post -> new PostListResponse(
-                        post.getId(),
-                        post.getTitle(),
-                        post.getCreatedAt().toLocalDate(),
-                        getNickname(post.getWriterId()),
-                        post.getImageUrl()
-                ))
+                .map(post -> {
+                    UserInfo writerInfo = UserInfo.from(userReadService, post.getWriterId());
+                    return new PostListResponse(
+                            post.getId(),
+                            post.getTitle(),
+                            post.getCreatedAt().toLocalDate(),
+                            writerInfo.nickname(),
+                            post.getImageUrl()
+                    );
+                })
                 .toList();
     }
-
-    private UserInfo getUserInfo(Long userId) {
-        try {
-            UserInfoResponse user = userReadService.getUserInfo(userId);
-            if (user == null) return new UserInfo("알 수 없음", "");
-            return new UserInfo(
-                    user.getNickname() != null ? user.getNickname() : "알 수 없음",
-                    user.getThumbnailUrl() != null ? user.getThumbnailUrl() : ""
-            );
-        } catch (Exception e) {
-            return new UserInfo("알 수 없음", "");
-        }
-    }
-
-
-    private String getNickname(Long userId) {
-        return getUserInfo(userId).nickname();
-    }
-
-    private String getProfileImage(Long userId) {
-        return getUserInfo(userId).profileImage();
-    }
-
 
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
![image](https://github.com/user-attachments/assets/67069ab1-dd63-4ef2-98c8-da1cdea77a3e)
유저의 이미지와 닉네임을 가져오는 UserInfo 파일 추가

```
UserInfo userInfo = UserInfo.from(userReadService, userId);
String nickname = userInfo.nickname();
String profile = userInfo.profileImage();
```
로 사용하여 프로필과 닉네임을 가져오도록 변경

```
post.increaseView();
postRepository.save(post);
```
위의 코드를 사용하여 값이 증가한 view를 db에 저장

---

## 🔗 관련 이슈
- closes #80 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 댓글 및 게시글에서 사용자 정보(닉네임, 프로필 이미지)가 더욱 정확하게 조회되어 표시됩니다.

- **리팩터**
  - 사용자 정보 조회 로직이 통합되어 일관된 방식으로 사용자 정보를 제공합니다.
  - 내부 패키지 구조가 정리되어 코드의 유지보수성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->