### PR TITLE
Cs 439 fix/view값 증가하는 로직을 document에서 entity로 이동

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
+++ b/src/main/java/com/playus/communityservice/domain/post/controller/PostController.java
@@ -74,6 +74,7 @@ public class PostController implements PostControllerSpecification {
     public ResponseEntity<PostGetResponse> getPost(@PathVariable TeamTag tag,
                                                    @PathVariable Long postId,
                                                    @AuthenticationPrincipal JwtUser user) {
+        postService.increaseView(postId);
         PostGetResponse response = postReadOnlyService.getPost(postId, user);
         return ResponseEntity.ok(response);
     }
@@ -82,6 +83,7 @@ public class PostController implements PostControllerSpecification {
     public ResponseEntity<PostGetResponse> getPostById(@PathVariable Long writerId,
                                                        @PathVariable Long postId,
                                                        @AuthenticationPrincipal JwtUser user) {
+        postService.increaseView(postId);
         PostGetResponse response = postReadOnlyService.getPostById(writerId, postId, user);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/playus/communityservice/domain/post/document/PostDocument.java
+++ b/src/main/java/com/playus/communityservice/domain/post/document/PostDocument.java
@@ -82,5 +82,4 @@ public class PostDocument {
                 .build();
     }
 
-    public void increaseView() { this.view++; }
 }

--- a/src/main/java/com/playus/communityservice/domain/post/entity/Post.java
+++ b/src/main/java/com/playus/communityservice/domain/post/entity/Post.java
@@ -84,5 +84,7 @@ public class Post extends BaseTimeEntity {
     public void delete() {
         this.activated = false;
     }
+
+    public void increaseView() { this.view++; }
 }
 

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostReadOnlyService.java
@@ -53,9 +53,6 @@ public class PostReadOnlyService {
             throw new EntityNotFoundException("작성자와 게시글이 일치하지 않습니다.");
         }
 
-        post.increaseView();
-        postRepository.save(post);
-
         List<CommentGroupDocument> groups = commentGroupRepository.findAllByPostId(postId);
         List<Long> groupIds = groups.stream()
                 .map(CommentGroupDocument::getId)

--- a/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
+++ b/src/main/java/com/playus/communityservice/domain/post/service/PostService.java
@@ -136,5 +136,12 @@ public class PostService {
     public PresignedUrlForSaveImageResponse generatePresignedUrlForSaveImage(PresignedUrlForSaveImageRequest request) {
         return new PresignedUrlForSaveImageResponse(s3Service.generatePresignedUrl(request.imageFileName()));
     }
+
+    public void increaseView(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("게시글"));
+
+        post.increaseView(); // MySQL 기반 Entity의 view 필드 증가
+    }
 }
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
```
public void increaseView(Long postId) {
        Post post = postRepository.findById(postId)
                .orElseThrow(() -> new EntityNotFoundException("게시글"));

        post.increaseView(); // MySQL 기반 Entity의 view 필드 증가
    }
```
PostService 파일에 위 코드를 추가하여 조회수가 증가되여 저장되도록 함

`postService.increaseView(postId);`
를 Controller에 post를 조회하는 로직에 추가

`public void increaseView() { this.view++; }`
PostDocument에서 Post로 이동

---

## 🔗 관련 이슈
- closes #82 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 게시글 조회 시 조회수가 올바르게 증가하도록 동작이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->