### PR TITLE
Refactor: comment 알림 전송 시 request에 receiverId 추가

### DIFF
--- a/src/main/java/com/playus/communityservice/domain/comment/dto/comment_create/CommentCreateRequest.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/dto/comment_create/CommentCreateRequest.java
@@ -18,7 +18,7 @@ public record CommentCreateRequest(
         String content
 ) {
 
-    public static CommentCreateRequest of(Long postId, Long commentId, Long commentGroupId, String content) {
+    public static CommentCreateRequest of(Long postId, Long commentGroupId, String content) {
         return CommentCreateRequest.builder()
                 .postId(postId)
                 .commentGroupId(commentGroupId)

--- a/src/main/java/com/playus/communityservice/domain/comment/repository/write/CommentRepository.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/repository/write/CommentRepository.java
@@ -5,8 +5,10 @@ import com.playus.communityservice.domain.comment.entity.CommentGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByCommentGroup(CommentGroup commentGroup);
     boolean existsByCommentGroupAndActivatedTrue(CommentGroup commentGroup);
+    Optional<Comment> findByCommentOrderAndCommentGroup(long commentOrder, CommentGroup commentGroup);
 }

--- a/src/main/java/com/playus/communityservice/domain/comment/service/CommentService.java
+++ b/src/main/java/com/playus/communityservice/domain/comment/service/CommentService.java
@@ -72,11 +72,15 @@ public class CommentService {
 
         commentRepository.save(comment);
 
+
         // 알림 전송
         CommentNotificationEvent event = CommentNotificationEvent.of(
                 comment.getId(),
                 post.getId(),
                 comment.getUserId(),
+                order == 1? post.getWriterId() : commentRepository.findByCommentOrderAndCommentGroup(1,commentGroup)
+                        .orElseThrow(() -> new EntityNotFoundException("댓글"))
+                        .getUserId(),
                 comment.getContent(),
                 comment.isActivated()
         );

--- a/src/main/java/com/playus/communityservice/global/client/CommentNotificationEvent.java
+++ b/src/main/java/com/playus/communityservice/global/client/CommentNotificationEvent.java
@@ -7,14 +7,17 @@ public record CommentNotificationEvent(
         Long commentId,
         Long postId,
         Long writerId,
+        Long receiverId,
         String content,
         boolean activated
 ) {
-    public static CommentNotificationEvent of(Long commentId, Long postId, Long writerId, String content, boolean activated) {
+    public static CommentNotificationEvent of(Long commentId, Long postId, Long writerId, Long receiverId,
+                                              String content, boolean activated) {
         return CommentNotificationEvent.builder()
                 .commentId(commentId)
                 .postId(postId)
                 .writerId(writerId)
+                .receiverId(receiverId)
                 .content(content)
                 .activated(activated)
                 .build();


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
```
order == 1? post.getWriterId() : commentRepository.findByCommentOrderAndCommentGroup(1,commentGroup)
                        .orElseThrow(() -> new EntityNotFoundException("댓글"))
                        .getUserId(),
```
위의 코드를 사용하여 알림 전송 수정

---

## 🔗 관련 이슈
- closes #84 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 댓글 알림 이벤트에 수신자 ID 필드가 추가되어, 대댓글 작성 시 알림 수신자가 정확히 지정됩니다.
- **버그 수정**
	- 대댓글 작성 시 알림이 항상 게시글 작성자에게만 전달되던 문제를 수정하여, 대댓글의 경우 부모 댓글 작성자에게 알림이 전송됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->